### PR TITLE
fix create method RPC endpoint method mismatch

### DIFF
--- a/src/lib/tableland-calls.ts
+++ b/src/lib/tableland-calls.ts
@@ -76,7 +76,7 @@ export async function create(
 ): Promise<CreateTableReceipt> {
   const message = await GeneralizedRPC.call(
     this,
-    "create",
+    "createTable",
     query,
     tableId,
     options


### PR DESCRIPTION
When `create` is called the underlying RPC endpoint is expecting the method name to be `tableland_createTable`.
This issue may have been the result of an incorrect conflict resolution.