### PR TITLE
error if connect called with unsupported network

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -27,6 +27,11 @@ export interface ConnectionReceipt {
   ethAccounts: Array<string>;
 }
 
+export interface SupportedNetwork {
+  key: string;
+  phrase: string;
+}
+
 /**
  * ColumnDescriptor gives metadata about a colum (name, type)
  */

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -1,11 +1,24 @@
 import { Signer, utils, ethers } from "ethers";
-import { ConnectionOptions, Connection, Token } from "../interfaces.js";
+import {
+  ConnectionOptions,
+  Connection,
+  Token,
+  SupportedNetwork,
+} from "../interfaces.js";
 import { list } from "./list.js";
 import { createToken } from "./token.js";
 import { query } from "./query.js";
 import { create } from "./create.js";
 
 declare let globalThis: any;
+
+const SUPPORTED_NETWORKS: SupportedNetwork[] = [
+  {
+    key: "rinkeby",
+    phrase: "Ethereum Rinkeby",
+  },
+];
+
 async function getSigner(): Promise<Signer> {
   await globalThis.ethereum.request({ method: "eth_requestAccounts" });
   const provider = new ethers.providers.Web3Provider(globalThis.ethereum);
@@ -51,6 +64,27 @@ export async function connect(options: ConnectionOptions): Promise<Connection> {
   }
 
   const signer = options.signer ?? (await getSigner());
+  const providerNetwork = await signer.provider?.getNetwork();
+
+  if (
+    !providerNetwork?.name ||
+    !SUPPORTED_NETWORKS.find((net) => net.key === providerNetwork.name)
+  ) {
+    const plural = SUPPORTED_NETWORKS.length > 1;
+    const phrase = plural
+      ? SUPPORTED_NETWORKS.map((net: any, i: number) => {
+          const last = i === SUPPORTED_NETWORKS.length - 1;
+          return last ? `and ${net.phrase}` : net.phrase;
+        })
+      : SUPPORTED_NETWORKS[0].phrase;
+
+    throw new Error(
+      `Only ${phrase} network${
+        plural ? "s are" : " is"
+      } currently supported. Switch your wallet connection and reconnect.`
+    );
+  }
+
   const token = await userCreatesToken(signer);
   const connectionObject: Connection = {
     get token() {

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -1,7 +1,9 @@
 import fetch from "jest-fetch-mock";
+import { Signer } from "ethers";
 import { connect } from "../src/main";
+import { ConnectionOptions } from "../src/interfaces";
 
-describe('connect function', function () {
+describe("connect function", function () {
   beforeAll(async function () {
     // reset in case another test file hasn't cleaned up
     fetch.resetMocks();
@@ -12,9 +14,46 @@ describe('connect function', function () {
     fetch.resetMocks();
   });
 
-  test.skip("Check connect", async function () {
+  test("exposes signer with correct address", async function () {
     const connection = await connect({ network: "testnet", host: "https://testnet.tableland.network" });
 
-    await expect(await connection.signer.getAddress()).toMatchObject("TODO: test connection");
+    await expect(connection.signer.getAddress()).toMatch("testaddress");
+  });
+
+  test("exposes public methods and properties",  async function () {
+    const connection = await connect({ network: "testnet", host: "https://testnet.tableland.network" });
+
+    await expect(connection.network).toBe("testnet");
+    await expect(connection.host).toBe("https://testnet.tableland.network");
+    await expect(connection.token instanceof Object).toBe(true);
+    await expect(typeof connection.token.token).toBe("string");
+    await expect(connection.signer instanceof Object).toBe(true);
+    await expect(typeof connection.list).toBe("function");
+    await expect(typeof connection.query).toBe("function");
+    await expect(typeof connection.create).toBe("function");
+  });
+
+  test("throws error if provider network is not supported", async function () {
+    await expect(async function () {
+      await connect({
+        network: "testnet",
+        host: "https://testnet.tableland.network",
+        signer: {
+          provider: {
+            getNetwork: async function () {
+              return { name: "ropsten", chainId: 1 };
+            },
+          } as any,
+          getAddress: async function () {
+            return "testaddress";
+          },
+          signMessage: async function () {
+            return "testsignedmessage";
+          }
+        } as unknown as Signer // convince type checks into letting us mock the signer
+      });
+    } as ConnectionOptions).rejects.toThrow(
+      "Only Ethereum Rinkeby network is currently supported. Switch your wallet connection and reconnect."
+    );
   });
 });

--- a/test/mock_modules/ethers.ts
+++ b/test/mock_modules/ethers.ts
@@ -7,15 +7,17 @@ export const ethers = {
         getSigner: function () {
           // mock signer
           return {
+            provider: {
+              getNetwork: async function () {
+                return { name: "rinkeby" };
+              }
+            },
             getAddress: function () {
               return "testaddress";
             },
             signMessage: async function () {
               return "testsignedmessage";
-            },
-            getNetwork: async function () {
-              return { name: "" };
-            },
+            }
           };
         },
       };


### PR DESCRIPTION
This fails with an informative error if the call to `connect` tries to use a provider network that tableland does not support.

@carsonfarmer I don't think this will affect the js-tableland-cli, but I wasn't able to get the cli to build and package 