### PR TITLE
Allow calling connect with an existing token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@textile/tableland",
-  "version": "0.0.8-dev4",
+  "version": "0.0.8-dev7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@textile/tableland",
-      "version": "0.0.8-dev4",
+      "version": "0.0.8-dev7",
       "license": "MIT",
       "dependencies": {
         "@babel/preset-env": "^7.16.11",
@@ -34,6 +34,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^3.4.1",
         "eslint-plugin-promise": "^5.1.1",
+        "flush-promises": "^1.0.2",
         "jest": "^27.4.7",
         "jest-fetch-mock": "^3.0.3",
         "jest-ts-webcompat-resolver": "^1.0.0",
@@ -5395,6 +5396,12 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "dev": true
+    },
+    "node_modules/flush-promises": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz",
+      "integrity": "sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==",
       "dev": true
     },
     "node_modules/form-data": {
@@ -12622,6 +12629,12 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "dev": true
+    },
+    "flush-promises": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz",
+      "integrity": "sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==",
       "dev": true
     },
     "form-data": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-promise": "^5.1.1",
+    "flush-promises": "^1.0.2",
     "jest": "^27.4.7",
     "jest-fetch-mock": "^3.0.3",
     "jest-ts-webcompat-resolver": "^1.0.0",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -16,7 +16,7 @@ export interface Token {
 }
 
 export interface ConnectionOptions {
-  jwsToken?: Token;
+  token?: Token;
   signer?: Signer;
   host?: string;
   network?: string;

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -85,7 +85,7 @@ export async function connect(options: ConnectionOptions): Promise<Connection> {
     );
   }
 
-  const token = await userCreatesToken(signer);
+  const token = options.token ?? (await userCreatesToken(signer));
   const connectionObject: Connection = {
     get token() {
       return token;

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -1,5 +1,6 @@
 import fetch from "jest-fetch-mock";
 import { Signer } from "ethers";
+import flushPromises from 'flush-promises';
 import { connect } from "../src/main";
 import { ConnectionOptions } from "../src/interfaces";
 
@@ -31,6 +32,24 @@ describe("connect function", function () {
     await expect(typeof connection.list).toBe("function");
     await expect(typeof connection.query).toBe("function");
     await expect(typeof connection.create).toBe("function");
+  });
+
+  test("allows specifying connection token", async function () {
+    const connection1 = await connect({ network: "testnet", host: "https://testnet.tableland.network" });
+
+    // We wait for over 1 second so that if the two connections are generating different tokens
+    // then the expirations will be different. This will ensure the assertion will only succeed
+    //  if the passed in token value is used
+    await new Promise((resolve) => setTimeout(() => resolve(null), 1001));
+    await flushPromises();
+
+    const connection2 = await connect({
+      network: "testnet",
+      host: "https://testnet.tableland.network",
+      token: connection1.token
+    });
+
+    await expect(connection1.token.token === connection2.token.token).toBe(true);
   });
 
   test("throws error if provider network is not supported", async function () {


### PR DESCRIPTION
Fix #21  This allows the developer using the SDK to save tokens and reuse them across different page loads, ect...