### PR TITLE
Add dryrun to create calls to avoid unneeded mint

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,6 +57,8 @@ export interface CreateTableOptions {
   description?: string;
   /** If your table was minted, but never created on tableland, use this param to create it. */
   id?: string;
+  /** do a dry run of create to see if the create statement is valid without creating the table */
+  dryrun?: boolean;
 }
 
 export interface CreateTableReceipt {

--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -21,6 +21,15 @@ export async function create(
   const authorized = await tablelandCalls.checkAuthorizedList.call(this);
   if (!authorized) throw new Error("You are not authorized to create a table");
   // Validation
+
+  // This "dryrun" is done to validate that the query statement is considered valid.
+  // We check this before minting the token, so the caller won't succeed at minting a token
+  // then fail to create the table on the Tableland network
+  await tablelandCalls.create.call(this, query, "1", {
+    dryrun: true,
+    ...options,
+  });
+
   let id = options.id;
   if (!id) {
     const { tableId } = await registerTable.call(this);

--- a/src/lib/tableland-calls.ts
+++ b/src/lib/tableland-calls.ts
@@ -47,6 +47,7 @@ async function GeneralizedRPC(
       id: tableId,
       controller: address,
       type: options?.type,
+      dryrun: options?.dryrun,
     },
   ];
 

--- a/test/createTable.test.ts
+++ b/test/createTable.test.ts
@@ -2,6 +2,8 @@ import fetch from "jest-fetch-mock";
 import { connect } from "../src/main";
 import {
   FetchAuthorizedListSuccess,
+  FetchCreateDryRunError,
+  FetchCreateDryRunSuccess,
   FetchCreateTableOnTablelandSuccess,
 } from "./fauxFetch";
 
@@ -23,11 +25,25 @@ describe("create method", function () {
 
   test("Create table works", async function () {
     fetch.mockResponseOnce(FetchAuthorizedListSuccess);
+    fetch.mockResponseOnce(FetchCreateDryRunSuccess);
     fetch.mockResponseOnce(FetchCreateTableOnTablelandSuccess);
 
     const createReceipt = await connection.create(
-      "CREATE TABLE Hello (id int primary key, val text)"
+      "CREATE TABLE hello (id int primary key, val text);"
     );
-    await expect(createReceipt.name).toEqual("Hello_115");
+    await expect(createReceipt.name).toEqual("hello_115");
+  });
+
+  test("Create table throws if dryrun fails", async function () {
+    fetch.mockResponseOnce(FetchAuthorizedListSuccess);
+    fetch.mockResponseOnce(FetchCreateDryRunError);
+    fetch.mockResponseOnce(FetchCreateTableOnTablelandSuccess);
+
+    await expect(async function () {
+      await connection.create(
+        "CREATE TABLE 123hello (id int primary key, val text);"
+      )
+    }).rejects.toThrow("TEST ERROR: invalid sql near 123");
+
   });
 });

--- a/test/fauxFetch.ts
+++ b/test/fauxFetch.ts
@@ -12,16 +12,39 @@ export const FetchAuthorizedListSuccess = async () => {
   };
 };
 
+export const FetchCreateDryRunSuccess = async () => {
+  return {
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        name: "hello_1",
+      },
+    }),
+  };
+};
+
 export const FetchCreateTableOnTablelandSuccess = async () => {
   return {
     body: JSON.stringify({
       jsonrpc: "2.0",
       id: 1,
       result: {
-        name: "Hello_115",
+        name: "hello_115",
       },
     }),
   };
+};
+
+export const FetchCreateDryRunError = async () => {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    error: {
+      code: -32000,
+      message: "TEST ERROR: invalid sql near 123"
+    }
+  });
 };
 
 export const FetchSelectQuerySuccess = async () => {


### PR DESCRIPTION
Fixes #24

This adds a check of the SQL statement intended to be used to create a table before the minting of the token in the SC.
We need to wait to publish this change until https://github.com/textileio/go-tableland/pull/63 is deployed to testnet