### PR TITLE
Joe/response types

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -69,8 +69,10 @@ export interface Row extends Array<any> {
 export type KeyVal<T = any> = [string, T];
 
 export interface ReadQueryResult {
-  columns: Array<Column>;
-  rows: Array<Row>;
+  data: {
+    columns: Array<Column>;
+    rows: Array<Row>;
+  };
 }
 
 export interface CreateTableOptions {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -58,21 +58,15 @@ export interface ColumnDescriptor {
   name: string;
 }
 
-export interface Column extends Array<any> {
-  [index: number]: ColumnDescriptor;
-}
-
-export interface Row extends Array<any> {
-  [index: number]: string | number;
-}
-
 export type KeyVal<T = any> = [string, T];
 
+export type Column = Array<ColumnDescriptor>;
+
+export type Row = Array<string | number | boolean>;
+
 export interface ReadQueryResult {
-  data: {
-    columns: Array<Column>;
-    rows: Array<Row>;
-  };
+  columns: Array<Column>;
+  rows: Array<Row>;
 }
 
 export interface CreateTableOptions {

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -1,3 +1,4 @@
+/* eslint-disable node/no-unpublished-import */
 import { Signer, utils, ethers } from "ethers";
 import {
   ConnectionOptions,

--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -1,3 +1,4 @@
+/* eslint-disable node/no-unpublished-import */
 import {
   CreateTableOptions,
   CreateTableReceipt,

--- a/src/lib/eth-calls.ts
+++ b/src/lib/eth-calls.ts
@@ -1,3 +1,4 @@
+/* eslint-disable node/no-unpublished-import */
 /* eslint-disable-next-line camelcase */
 import { TablelandTables__factory } from "@tableland/eth";
 import { TableRegistrationReceipt, Connection } from "../interfaces.js";

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,3 +1,4 @@
+/* eslint-disable node/no-unpublished-import */
 import { StructureHashReceipt, Connection } from "../interfaces.js";
 import * as tablelandCalls from "./tableland-calls.js";
 /**

--- a/src/lib/list.ts
+++ b/src/lib/list.ts
@@ -1,3 +1,4 @@
+/* eslint-disable node/no-unpublished-import */
 import { TableMetadata, Connection } from "../interfaces.js";
 
 export async function list(this: Connection): Promise<TableMetadata[]> {

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,3 +1,5 @@
+/* eslint-disable node/no-unpublished-import */
+
 /**
  * Send a SQL query to tableland network
  * @param query A SQL query to run

--- a/src/lib/tableland-calls.ts
+++ b/src/lib/tableland-calls.ts
@@ -33,13 +33,22 @@ async function sendResponse(res: any) {
   const json = await res.json();
   // NOTE: we are leaving behind the error code because the Error type does not allow for a `code` property
   if (json.error) throw new Error(json.error.message);
+  if (!json.result) throw new Error("Malformed RPC response");
 
-  return camelCaseKeys(json.result);
+  // response to reads is in `result.data` key, note: data === null for writes
+  if (json.result.data) return camelCaseKeys(json.result.data);
+  // response to create or hash is in `result`
+  if (json.result.name || json.result.structure_hash) {
+    return camelCaseKeys(json.result);
+  }
+
+  // return undefined for writes
+  return undefined;
 }
 
 // Take an Object with any symantic for key naming and return a new Object with keys that are lowerCamelCase
 // Example: `camelCaseKeys({structure_hash: "123"})` returns `{structureHash: "123"}`
-function camelCaseKeys(obj: object) {
+function camelCaseKeys(obj: any) {
   return Object.fromEntries(
     Object.entries(obj).map((entry: KeyVal) => {
       const key = entry[0];

--- a/src/lib/tableland-calls.ts
+++ b/src/lib/tableland-calls.ts
@@ -1,3 +1,4 @@
+/* eslint-disable node/no-unpublished-import */
 /* eslint-disable node/no-missing-import */
 
 import camelCase from "camelcase";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,2 +1,3 @@
+/* eslint-disable node/no-unpublished-import */
 export { connect } from "./lib/connector.js";
 export * from "./interfaces.js";

--- a/test/fauxFetch.ts
+++ b/test/fauxFetch.ts
@@ -52,9 +52,7 @@ export const FetchSelectQuerySuccess = async () => {
   return JSON.stringify({
     jsonrpc: "2.0",
     id: 1,
-    result: {
-      data: {columns: ['colname'], rows: ['val1']}
-    }
+    result: {data: {columns: [{name: 'colname'}], rows: ['val1']}}
   });
 };
 

--- a/test/fauxFetch.ts
+++ b/test/fauxFetch.ts
@@ -52,7 +52,9 @@ export const FetchSelectQuerySuccess = async () => {
   return JSON.stringify({
     jsonrpc: "2.0",
     id: 1,
-    result: {columns: ['colname'], rows: ['val1']}
+    result: {
+      data: {columns: ['colname'], rows: ['val1']}
+    }
   });
 };
 

--- a/test/runQuery.test.ts
+++ b/test/runQuery.test.ts
@@ -23,7 +23,7 @@ describe("query method", function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res = await connection.query("SELECT * FROM test_1;");
-    await expect(res).toEqual({columns: ["colname"], rows: ["val1"]});
+    await expect(res).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
   });
 
   test("returns RPC result when insert query succeeds", async function () {
@@ -57,35 +57,35 @@ describe("query method", function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res1 = await connection.query("select * from test_1;");
-    await expect(res1).toEqual({columns: ["colname"], rows: ["val1"]});
+    await expect(res1).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
 
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res2 = await connection.query("sELEct * frOM test_1;");
-    await expect(res2).toEqual({columns: ["colname"], rows: ["val1"]});
+    await expect(res2).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
   });
 
   test("parses tablename regardless of whitespace", async function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res1 = await connection.query("INSERT INTO test_1(colname) Values ('val6');");
-    await expect(res1).toEqual({columns: ["colname"], rows: ["val1"]});
+    await expect(res1).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
 
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res2 = await connection.query("sELEct * frOM test_1;");
-    await expect(res2).toEqual({columns: ["colname"], rows: ["val1"]});
+    await expect(res2).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
   });
 
   test("parses tablename when inside double-quotes", async function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res1 = await connection.query("INSERT INTO \"test_1\" (colname) Values ('val6');");
-    await expect(res1).toEqual({columns: ["colname"], rows: ["val1"]});
+    await expect(res1).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
 
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res2 = await connection.query("sELEct * frOM test_1;");
-    await expect(res2).toEqual({columns: ["colname"], rows: ["val1"]});
+    await expect(res2).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
   });
 });

--- a/test/runQuery.test.ts
+++ b/test/runQuery.test.ts
@@ -23,21 +23,21 @@ describe("query method", function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res = await connection.query("SELECT * FROM test_1;");
-    await expect(res).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
+    await expect(res).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
   });
 
   test("returns RPC result when insert query succeeds", async function () {
     fetch.mockResponseOnce(FetchInsertQuerySuccess);
 
     const res = await connection.query("INSERT INTO test_1 (colname) values (val2);");
-    await expect(res).toEqual({data: null});
+    await expect(res).toEqual(undefined);
   });
 
   test("returns RPC result when update query succeeds", async function () {
     fetch.mockResponseOnce(FetchUpdateQuerySuccess);
 
     const res = await connection.query("UPDATE test_1 SET colname = val3 where colname = val2;");
-    await expect(res).toEqual({data: null});
+    await expect(res).toEqual(undefined);
   });
 
   test("maps arguments to correct RPC params", async function () {
@@ -57,35 +57,35 @@ describe("query method", function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res1 = await connection.query("select * from test_1;");
-    await expect(res1).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
+    await expect(res1).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
 
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res2 = await connection.query("sELEct * frOM test_1;");
-    await expect(res2).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
+    await expect(res2).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
   });
 
   test("parses tablename regardless of whitespace", async function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res1 = await connection.query("INSERT INTO test_1(colname) Values ('val6');");
-    await expect(res1).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
+    await expect(res1).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
 
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res2 = await connection.query("sELEct * frOM test_1;");
-    await expect(res2).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
+    await expect(res2).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
   });
 
   test("parses tablename when inside double-quotes", async function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res1 = await connection.query("INSERT INTO \"test_1\" (colname) Values ('val6');");
-    await expect(res1).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
+    await expect(res1).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
 
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const res2 = await connection.query("sELEct * frOM test_1;");
-    await expect(res2).toEqual({data: {columns: ["colname"], rows: ["val1"]}});
+    await expect(res2).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
   });
 });


### PR DESCRIPTION
Fixes #36

The successful RPC response data has a few different schema depending on the endpoint, and on how the endpoint is called.  Keeping in mind that some of this will change as this season's changes to how we interact with Smart Contracts start to be implemented.