### PR TITLE
Add Bearer token to requests to list an addresses tables

### DIFF
--- a/src/lib/list.ts
+++ b/src/lib/list.ts
@@ -4,7 +4,12 @@ export async function list(this: Connection): Promise<TableMetadata[]> {
   const address = await this.signer.getAddress();
 
   const resp: TableMetadata[] = await fetch(
-    `${this.host}/tables/controller/${address}`
+    `${this.host}/tables/controller/${address}`,
+    {
+      headers: {
+        Authorization: `Bearer ${this.token.token}`,
+      }
+    },
   ).then((r) => r.json());
 
   return resp;


### PR DESCRIPTION
This adds an Authorization header to http requests to `/tables/controller/${address}`.  This matches what is expected by the v2 branch of the Validator.
We are sending the SIWE token to this route now because the Validator has become multi-chain and it will use the decoded SIWE message to determine the chainId.