### PR TITLE
Allow specifying the contract as a connection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ const connection = await connect({
  - signer: Optionally pass in a Signer object. This can be used if the caller wants to use a signer other than the browser default. This is useful in the node.js enviroment, or really anywhere except within a browser that has a built-in wallet.
  - host: This is the http url of the validator that the caller wants to connect to. This is optional and defaults to https://testnet.tableland.network. If host is not specified then network must be equal to 'testnet'
  - network: This is the name of the network, and as of this pr can be one of local, optimism-kovan-staging, staging, or testnet. This name is mapped to the address of a contract that has been deployed and is being watched by a Tableland network Validator on that chain. Note: 'local' is a locally running hardhat node, which requires that the caller has already got that running. This is useful for contributors.
- - contract: This PR will add the optional contract option. If specified the SDKs direct calls to the SC will go to this address. This is potentially useful for testing and local development. Note: the abi of the contract must match the abi of the version of eth-tableland was used for the build of the SDK. This is useful for contributors.
+ - contract: Optionally pass in the address of a contract for making direct calls. If specified, the SDK's direct calls to the smart contract will go to _this_ address (rather than the default contract). This is potentially useful for testing and local development. Note: the ABI of the contract must match the ABI of the version of `eth-tableland` that was used to build the SDK. This is useful for contributors.
 
 ## Creating Tables
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ const connection = await connect({
 });
 ```
 
+### Connection options
+
+ - token: Optionally pass in a Bearer token. This can be used if the caller doesn't want the SDK to generate a SIWE token. Potential uses include apps that save the user's SIWE token so they don't have to prompt the user to sign a new token on every page refresh
+ - signer: Optionally pass in a Signer object. This can be used if the caller wants to use a signer other than the browser default. This is useful in the node.js enviroment, or really anywhere except within a browser that has a built-in wallet.
+ - host: This is the http url of the validator that the caller wants to connect to. This is optional and defaults to https://testnet.tableland.network. If host is not specified then network must be equal to 'testnet'
+ - network: This is the name of the network, and as of this pr can be one of local, optimism-kovan-staging, staging, or testnet. This name is mapped to the address of a contract that has been deployed and is being watched by a Tableland network Validator on that chain. Note: 'local' is a locally running hardhat node, which requires that the caller has already got that running. This is useful for contributors.
+ - contract: This PR will add the optional contract option. If specified the SDKs direct calls to the SC will go to this address. This is potentially useful for testing and local development. Note: the abi of the contract must match the abi of the version of eth-tableland was used for the build of the SDK. This is useful for contributors.
+
 ## Creating Tables
 
 Like most relational database systems, Tableland requires the user to create tables for storing, querying, and relating data. This is done via the [`create`](https://tablelandnetwork.github.io/js-tableland/modules.html#create) function. The `create` function takes a plain SQL statement string. All tables require a primary key field called `id` to be valid. Most valid SQL _constraints_ are supported, and the following data types are currently supported:

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,6 +20,7 @@ export interface ConnectionOptions {
   signer?: Signer;
   host?: string;
   network?: string;
+  contract?: string;
 }
 
 export interface RpcParams {
@@ -119,6 +120,7 @@ export interface Connection {
   signer: Signer;
   token: Token;
   network: string;
+  contract: string;
   list: () => Promise<TableMetadata[]>;
   create: (
     query: string,

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -36,6 +36,7 @@ export async function userCreatesToken(
 export async function connect(options: ConnectionOptions): Promise<Connection> {
   const network = options.network ?? "testnet";
   const host = options.host ?? "https://testnet.tableland.network";
+  const contract = options.contract ?? "";
 
   if (network !== "testnet" && !options.host) {
     throw Error(
@@ -85,6 +86,9 @@ export async function connect(options: ConnectionOptions): Promise<Connection> {
     },
     get host() {
       return host;
+    },
+    get contract() {
+      return contract;
     },
     get signer() {
       return signer;

--- a/src/lib/eth-calls.ts
+++ b/src/lib/eth-calls.ts
@@ -12,12 +12,9 @@ async function registerTable(
   const address = await signer.getAddress();
   /* eslint-disable-next-line camelcase */
 
-  const network = this.network;
+  const contractAddress = this.contract ?? contractAddresses[this.network];
 
-  const contract = TablelandTables__factory.connect(
-    contractAddresses[network],
-    signer
-  );
+  const contract = TablelandTables__factory.connect(contractAddress, signer);
 
   const tx = await contract.createTable(address, query);
 


### PR DESCRIPTION
This PR will expose an option to set the address of the contract you want to connect to.  This is being done to enable easier development and testing of the registry Smart Contract.

With this change the connection options would become:
 - token: Optionally pass in a Bearer token.  This can be used if the caller doesn't want the SDK to generate a SIWE token.  Potential uses include apps that save the user's SIWE token so they don't have to prompt the user to sign a new token on eevery page refresh
 - signer: Optionally pass in a Signer object.  This can be used if the caller wants to use a signer other than the browser default.  This is useful in the node.js enviroment, or really anywhere except within a browser that has a built-in wallet.
 - host:  This is the http url of the validator that the caller wants to connect to.  This is optional and defaults to https://testnet.tableland.network.  If host is not specified then network must be equal to 'testnet'
 - network: This is the name of the network, and as of this pr can be one of local, optimism-kovan-staging, staging, or testnet.  This name is mapped to the address of a contract that has been deployed and is being watched by a Tableland network Validator on that chain.  Note: 'local' is a locally running hardhat node, which requires that the caller has already got that running.
 - contract:  This PR will add the optional contract option.  If specified the SDKs direct calls to the SC will go to this address.  This is potentially useful for testing and local development.  Note: the abi of the contract must match the abi of the version of eth-tableland was used for the build of the SDK

