### PR TITLE
Update `list` url to include chainId

### DIFF
--- a/src/lib/list.ts
+++ b/src/lib/list.ts
@@ -3,8 +3,12 @@ import { TableMetadata, Connection } from "../interfaces.js";
 export async function list(this: Connection): Promise<TableMetadata[]> {
   const address = await this.signer.getAddress();
 
+  // TODO: this check is potentially too restrictive, see issue #22
+  const providerNetwork = await this.signer.provider?.getNetwork();
+  const chainId = providerNetwork?.chainId ?? "4";
+
   const resp: TableMetadata[] = await fetch(
-    `${this.host}/tables/controller/${address}`
+    `${this.host}/chain/${chainId}/tables/controller/${address}`
   ).then((r) => r.json());
 
   return resp;


### PR DESCRIPTION
This matches the list methods to the newest v2 go-tableland changes