### PR TITLE
Fix regression in create method after custom contract option

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -124,7 +124,7 @@ export interface Connection {
   list: () => Promise<TableMetadata[]>;
   create: (
     query: string,
-    options: CreateTableOptions
+    options?: CreateTableOptions
   ) => Promise<ContractReceipt>;
   query: (query: string) => Promise<null | ReadQueryResult>;
   hash: (query: string) => Promise<StructureHashReceipt>;

--- a/src/lib/eth-calls.ts
+++ b/src/lib/eth-calls.ts
@@ -12,10 +12,12 @@ async function registerTable(
   const address = await signer.getAddress();
   /* eslint-disable-next-line camelcase */
 
-  const contractAddress = this.contract ?? contractAddresses[this.network];
+  const contractAddress = this.contract || contractAddresses[this.network];
+
+  if (!contractAddress)
+    throw new Error(`no contract found for ${this.network} network`);
 
   const contract = TablelandTables__factory.connect(contractAddress, signer);
-
   const tx = await contract.createTable(address, query);
 
   return await tx.wait();


### PR DESCRIPTION
When the custom contract address option was added there was a regression in the create method