### PR TITLE
Updates to match changes to RPC endpoint

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -69,6 +69,10 @@ export type Column = Array<ColumnDescriptor>;
 
 export type Row = Array<string | number | boolean>;
 
+export interface WriteQueryResult {
+  data: null;
+}
+
 export interface ReadQueryResult {
   columns: Array<Column>;
   rows: Array<Row>;
@@ -131,9 +135,8 @@ export interface Connection {
      **/
     prefix?: string
   ) => Promise<ContractReceipt>;
-  query: (query: string) => Promise<null | ReadQueryResult>; // TODO
-  // read: (query: string) => Promise<null | ReadQueryResult>;
-  // write: (query: string) => Promise<null | {data: null}>;
+  read: (query: string) => Promise<null | ReadQueryResult>;
+  write: (query: string) => Promise<null | WriteQueryResult>;
   hash: (query: string) => Promise<StructureHashReceipt>;
   receipt: (txnHash: string) => Promise<ReceiptResult>;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -39,11 +39,11 @@ export type KeyVal<T = any> = [string, T];
 
 export type Column = Array<{ name: string }>;
 
-export type Row = Array<string | number | boolean>;
-
-export interface ReadQueryResult {
+export interface ReadQueryResult<
+  Row extends Array<string | number | boolean> = Array<any>
+> {
   columns: Array<Column>;
-  rows: Array<Row>;
+  rows: Row;
 }
 
 export interface WriteQueryResult {
@@ -106,5 +106,5 @@ export interface Connection {
   read: (query: string) => Promise<ReadQueryResult>;
   write: (query: string) => Promise<WriteQueryResult>;
   hash: (query: string) => Promise<StructureHashReceipt>;
-  receipt: (txnHash: string) => Promise<ReceiptResult | void>;
+  receipt: (txnHash: string) => Promise<ReceiptResult | undefined>;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,14 +1,11 @@
 import { BigNumber, ContractReceipt, Signer } from "ethers";
 
 export interface TableMetadata {
-  id: string;
+  controller: string;
   /* eslint-disable-next-line camelcase */
-  created_at?: string;
-  description?: string;
-  tablename?: string;
-  name?: string;
-  controller?: string;
-  structure?: string;
+  created_at: string;
+  name: string;
+  structure: string;
 }
 
 export interface Token {
@@ -24,30 +21,12 @@ export interface ConnectionOptions {
 }
 
 export interface RpcParams {
-  controller?: boolean;
-  createStatement?: string;
-  description?: string;
-  dryrun?: boolean;
-  statement?: string;
-  tableId?: string;
-  txnHash?: string;
-}
-
-export interface RpcRequestParam {
   controller?: string;
   /* eslint-disable-next-line camelcase */
   create_statement?: string;
-  description?: string;
-  dryrun?: boolean;
-  id?: string;
   statement?: string;
   /* eslint-disable-next-line camelcase */
   txn_hash?: string;
-}
-
-export interface ConnectionReceipt {
-  jwsToken: Token;
-  ethAccounts: Array<string>;
 }
 
 export interface SupportedNetwork {
@@ -56,26 +35,19 @@ export interface SupportedNetwork {
   chainId: number;
 }
 
-/**
- * ColumnDescriptor gives metadata about a colum (name, type)
- */
-export interface ColumnDescriptor {
-  name: string;
-}
-
 export type KeyVal<T = any> = [string, T];
 
-export type Column = Array<ColumnDescriptor>;
+export type Column = Array<{ name: string }>;
 
 export type Row = Array<string | number | boolean>;
-
-export interface WriteQueryResult {
-  data: null;
-}
 
 export interface ReadQueryResult {
   columns: Array<Column>;
   rows: Array<Row>;
+}
+
+export interface WriteQueryResult {
+  hash: string;
 }
 
 export interface ReceiptResult {
@@ -118,16 +90,12 @@ export interface Connection {
   contract: string;
   list: () => Promise<TableMetadata[]>;
   create: (
-    /** The ChainId of the chain this table should be created on.
-     *  MUST match the chain that the SDK connected to
-     **/
-    chainId: number,
     /** The schema that defines the columns and constraints of the table,
      *  e.g.
-     * `id int NOT NULL,
-     *  name char(50) NOT NULL,
-     *  favorite_food char(50),
-     *  PRIMARY KEY (id)`
+     `id int NOT NULL,
+      name char(50) NOT NULL,
+      favorite_food char(50),
+      PRIMARY KEY (id)`
      */
     schema: string,
     /** an optional prefix to the tablename that will be assigned to this table.
@@ -135,8 +103,8 @@ export interface Connection {
      **/
     prefix?: string
   ) => Promise<ContractReceipt>;
-  read: (query: string) => Promise<null | ReadQueryResult>;
-  write: (query: string) => Promise<null | WriteQueryResult>;
+  read: (query: string) => Promise<ReadQueryResult>;
+  write: (query: string) => Promise<WriteQueryResult>;
   hash: (query: string) => Promise<StructureHashReceipt>;
-  receipt: (txnHash: string) => Promise<ReceiptResult>;
+  receipt: (txnHash: string) => Promise<ReceiptResult | void>;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -84,15 +84,6 @@ export interface ReceiptResult {
   error?: string;
 }
 
-export interface CreateTableOptions {
-  /** A human readable description of the nature and purpoe of the table */
-  description?: string;
-  /** If your table was minted, but never created on tableland, use this param to create it. */
-  id?: string;
-  /** do a dry run of create to see if the create statement is valid without creating the table */
-  dryrun?: boolean;
-}
-
 export interface CreateTableReceipt {
   name: string;
   structureHash: string;
@@ -123,10 +114,26 @@ export interface Connection {
   contract: string;
   list: () => Promise<TableMetadata[]>;
   create: (
-    query: string,
-    options?: CreateTableOptions
+    /** The ChainId of the chain this table should be created on.
+     *  MUST match the chain that the SDK connected to
+     **/
+    chainId: number,
+    /** The schema that defines the columns and constraints of the table,
+     *  e.g.
+     * `id int NOT NULL,
+     *  name char(50) NOT NULL,
+     *  favorite_food char(50),
+     *  PRIMARY KEY (id)`
+     */
+    schema: string,
+    /** an optional prefix to the tablename that will be assigned to this table.
+     *  If supplied, it must conform to the rules of SQL table names
+     **/
+    prefix?: string
   ) => Promise<ContractReceipt>;
-  query: (query: string) => Promise<null | ReadQueryResult>;
+  query: (query: string) => Promise<null | ReadQueryResult>; // TODO
+  // read: (query: string) => Promise<null | ReadQueryResult>;
+  // write: (query: string) => Promise<null | {data: null}>;
   hash: (query: string) => Promise<StructureHashReceipt>;
   receipt: (txnHash: string) => Promise<ReceiptResult>;
 }

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -2,7 +2,7 @@ import { Signer, ethers } from "ethers";
 import { ConnectionOptions, Connection, Token } from "../interfaces.js";
 import { list } from "./list.js";
 import { createToken } from "./token.js";
-import { query } from "./query.js";
+import { read, write } from "./query.js";
 import { create } from "./create.js";
 import { hash } from "./hash.js";
 import { receipt } from "./tableland-calls.js";
@@ -96,8 +96,11 @@ export async function connect(options: ConnectionOptions): Promise<Connection> {
     get list() {
       return list;
     },
-    get query() {
-      return query;
+    get read() {
+      return read;
+    },
+    get write() {
+      return write;
     },
     get create() {
       return create;

--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -10,8 +10,11 @@ import { registerTable } from "./eth-calls.js";
  */
 export async function create(
   this: Connection,
-  query: string
+  chainId: number,
+  schema: string,
+  prefix: string = ""
 ): Promise<ContractReceipt> {
+  const query = `CREATE TABLE ${prefix}_${chainId} (${schema});`;
   // This "dryrun" is done to validate that the query statement is considered valid.
   // We check this before minting the token, so the caller won't succeed at minting a token
   // then fail to create the table on the Tableland network

--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -10,10 +10,14 @@ import { registerTable } from "./eth-calls.js";
  */
 export async function create(
   this: Connection,
-  chainId: number,
   schema: string,
   prefix: string = ""
 ): Promise<ContractReceipt> {
+  // TODO: This is realted to issue#22, we might end up doing something like `await this.provider.getNetwork();`
+  const providerNetwork = await this.signer.provider?.getNetwork();
+  const chainId = providerNetwork?.chainId;
+  if (!chainId) throw new Error("cannot create table without provider network");
+
   const query = `CREATE TABLE ${prefix}_${chainId} (${schema});`;
   // This "dryrun" is done to validate that the query statement is considered valid.
   // We check this before minting the token, so the caller won't succeed at minting a token

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -4,12 +4,23 @@
  * @returns If read query, result-set. If write query, nothing.
  */
 
-import { ReadQueryResult, Connection } from "../interfaces.js";
+import {
+  ReadQueryResult,
+  WriteQueryResult,
+  Connection,
+} from "../interfaces.js";
 import * as tablelandCalls from "./tableland-calls.js";
 
-export async function query(
+export async function read(
   this: Connection,
   query: string
 ): Promise<ReadQueryResult | null> {
-  return await tablelandCalls.query.call(this, query);
+  return await tablelandCalls.read.call(this, query);
+}
+
+export async function write(
+  this: Connection,
+  query: string
+): Promise<WriteQueryResult | null> {
+  return await tablelandCalls.write.call(this, query);
 }

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -14,13 +14,13 @@ import * as tablelandCalls from "./tableland-calls.js";
 export async function read(
   this: Connection,
   query: string
-): Promise<ReadQueryResult | null> {
+): Promise<ReadQueryResult> {
   return await tablelandCalls.read.call(this, query);
 }
 
 export async function write(
   this: Connection,
   query: string
-): Promise<WriteQueryResult | null> {
+): Promise<WriteQueryResult> {
   return await tablelandCalls.write.call(this, query);
 }

--- a/src/lib/tableland-calls.ts
+++ b/src/lib/tableland-calls.ts
@@ -105,7 +105,7 @@ async function write(
 async function receipt(
   this: Connection,
   txnHash: string
-): Promise<ReceiptResult | void> {
+): Promise<ReceiptResult | undefined> {
   const message = await GeneralizedRPC.call(this, "getReceipt", {
     txn_hash: txnHash,
   });
@@ -113,6 +113,7 @@ async function receipt(
 
   if (json.result.receipt) return camelCaseKeys(json.result.receipt);
   // if the transaction hasn't been digested return undefined
+  return undefined;
 }
 
 export { hash, list, receipt, read, write };

--- a/src/lib/tableland-calls.ts
+++ b/src/lib/tableland-calls.ts
@@ -6,6 +6,7 @@ import {
   RpcParams,
   RpcRequestParam,
   ReadQueryResult,
+  WriteQueryResult,
   ReceiptResult,
   KeyVal,
   Connection,
@@ -107,11 +108,10 @@ async function hash(
   return json as StructureHashReceipt;
 }
 
-async function query(
+async function read(
   this: Connection,
   query: string
 ): Promise<ReadQueryResult | null> {
-  // TODO: this only allows reads, this method should become `read`
   const message = await GeneralizedRPC.call(this, "runReadQuery", {
     statement: query,
   });
@@ -119,6 +119,19 @@ async function query(
   const json = await sendResponse(response);
 
   return json as ReadQueryResult;
+}
+
+async function write(
+  this: Connection,
+  query: string
+): Promise<WriteQueryResult | null> {
+  const message = await GeneralizedRPC.call(this, "relayWriteQuery", {
+    statement: query,
+  });
+  const response = await SendCall.call(this, message);
+  const json = await sendResponse(response);
+
+  return json as WriteQueryResult;
 }
 
 async function receipt(
@@ -134,4 +147,4 @@ async function receipt(
   return json as ReceiptResult;
 }
 
-export { receipt, query, list, hash, TableMetadata };
+export { hash, list, receipt, read, TableMetadata, write };

--- a/src/lib/tableland-calls.ts
+++ b/src/lib/tableland-calls.ts
@@ -111,7 +111,8 @@ async function query(
   this: Connection,
   query: string
 ): Promise<ReadQueryResult | null> {
-  const message = await GeneralizedRPC.call(this, "runSQL", {
+  // TODO: this only allows reads, this method should become `read`
+  const message = await GeneralizedRPC.call(this, "runReadQuery", {
     statement: query,
   });
   const response = await SendCall.call(this, message);

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -36,7 +36,8 @@ describe("connect function", function () {
     await expect(typeof connection.token.token).toBe("string");
     await expect(connection.signer instanceof Object).toBe(true);
     await expect(typeof connection.list).toBe("function");
-    await expect(typeof connection.query).toBe("function");
+    await expect(typeof connection.read).toBe("function");
+    await expect(typeof connection.write).toBe("function");
     await expect(typeof connection.create).toBe("function");
   });
 

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -47,8 +47,7 @@ describe("connect function", function () {
     fetch.mockResponseOnce(FetchCreateDryRunSuccess);
     fetch.mockResponseOnce(FetchCreateTableOnTablelandSuccess);
 
-    const createStatement = "CREATE TABLE hello (id int primary key, val text);";
-    await connection.create(createStatement);
+    await connection.create(31337, "id int primary key, val text", "hello");
 
     expect(factorySpy).toHaveBeenCalled();
     await expect(contractAddresses["testnet"]).toBe(factorySpy.mock.calls[0][0])

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -48,7 +48,7 @@ describe("connect function", function () {
     fetch.mockResponseOnce(FetchCreateDryRunSuccess);
     fetch.mockResponseOnce(FetchCreateTableOnTablelandSuccess);
 
-    await connection.create(31337, "id int primary key, val text", "hello");
+    await connection.create("id int primary key, val text", "hello");
 
     expect(factorySpy).toHaveBeenCalled();
     await expect(contractAddresses["testnet"]).toBe(factorySpy.mock.calls[0][0])

--- a/test/createTable.test.ts
+++ b/test/createTable.test.ts
@@ -1,4 +1,5 @@
 import fetch from "jest-fetch-mock";
+//import { ethers } from "./mock_modules/ethers";
 import { connect } from "../src/main";
 import {
   FetchCreateDryRunError,
@@ -11,6 +12,7 @@ describe("create method", function () {
   beforeAll(async function () {
     // reset in case another test file hasn't cleaned up
     fetch.resetMocks();
+    //const signer = ethers.providers.Web3Provider().getSigner();
     connection = await connect({
       network: "testnet",
       host: "https://testnet.tableland.network",
@@ -26,7 +28,7 @@ describe("create method", function () {
     fetch.mockResponseOnce(FetchCreateDryRunSuccess);
     fetch.mockResponseOnce(FetchCreateTableOnTablelandSuccess);
 
-    const txReceipt = await connection.create(31337, "id int primary key, val text");
+    const txReceipt = await connection.create("id int primary key, val text");
     const createReceipt = txReceipt.events[0];
     await expect(createReceipt.args.tokenId._hex).toEqual("0x015");
   });
@@ -37,7 +39,6 @@ describe("create method", function () {
 
     await expect(async function () {
       await connection.create(
-        31337,
         "id int primary key, val text",
         "123test"
       )

--- a/test/createTable.test.ts
+++ b/test/createTable.test.ts
@@ -26,8 +26,7 @@ describe("create method", function () {
     fetch.mockResponseOnce(FetchCreateDryRunSuccess);
     fetch.mockResponseOnce(FetchCreateTableOnTablelandSuccess);
 
-    const createStatement = "CREATE TABLE hello (id int primary key, val text);";
-    const txReceipt = await connection.create(createStatement);
+    const txReceipt = await connection.create(31337, "id int primary key, val text");
     const createReceipt = txReceipt.events[0];
     await expect(createReceipt.args.tokenId._hex).toEqual("0x015");
   });
@@ -38,7 +37,9 @@ describe("create method", function () {
 
     await expect(async function () {
       await connection.create(
-        "CREATE TABLE 123hello (id int primary key, val text);"
+        31337,
+        "id int primary key, val text",
+        "123test"
       )
     }).rejects.toThrow("TEST ERROR: invalid sql near 123");
 

--- a/test/fauxFetch.ts
+++ b/test/fauxFetch.ts
@@ -61,7 +61,7 @@ export const FetchInsertQuerySuccess = async () => {
     jsonrpc: "2.0",
     id: 1,
     result: {
-      data: null
+      tx: { hash: 'testhashinsertresponse' }
     }
   });
 };
@@ -71,7 +71,7 @@ export const FetchUpdateQuerySuccess = async () => {
     jsonrpc: "2.0",
     id: 1,
     result: {
-      data: null
+      tx: { hash: 'testhashinsertresponse' }
     }
   });
 };

--- a/test/mock_modules/ethers.ts
+++ b/test/mock_modules/ethers.ts
@@ -9,7 +9,10 @@ export const ethers = {
           return {
             provider: {
               getNetwork: async function () {
-                return { name: "rinkeby" };
+                return {
+                  name: "rinkeby",
+                  chainId: 4
+                };
               }
             },
             getAddress: function () {

--- a/test/runQuery.test.ts
+++ b/test/runQuery.test.ts
@@ -6,7 +6,7 @@ import {
   FetchUpdateQuerySuccess
 } from "../test/fauxFetch";
 
-describe("query method", function () {
+describe("read and write methods", function () {
   let connection: any;
   beforeAll(async function () {
     // reset in case another test file hasn't cleaned up
@@ -22,21 +22,21 @@ describe("query method", function () {
   test("returns RPC result when select query succeeds", async function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
-    const res = await connection.query("SELECT * FROM test_1;");
+    const res = await connection.read("SELECT * FROM test_1;");
     await expect(res).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
   });
 
   test("returns RPC result when insert query succeeds", async function () {
     fetch.mockResponseOnce(FetchInsertQuerySuccess);
 
-    const res = await connection.query("INSERT INTO test_1 (colname) values (val2);");
+    const res = await connection.write("INSERT INTO test_1 (colname) values (val2);");
     await expect(res).toEqual(undefined);
   });
 
   test("returns RPC result when update query succeeds", async function () {
     fetch.mockResponseOnce(FetchUpdateQuerySuccess);
 
-    const res = await connection.query("UPDATE test_1 SET colname = val3 where colname = val2;");
+    const res = await connection.write("UPDATE test_1 SET colname = val3 where colname = val2;");
     await expect(res).toEqual(undefined);
   });
 
@@ -44,7 +44,7 @@ describe("query method", function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
     const queryStaement = "SELECT * FROM test_1;";
-    await connection.query(queryStaement);
+    await connection.read(queryStaement);
     const payload = JSON.parse(fetch.mock.calls[0][1]?.body as string);
 
     await expect(payload.params[0]?.controller).toEqual("testaddress");
@@ -56,36 +56,36 @@ describe("query method", function () {
   test("is case insensitive", async function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
-    const res1 = await connection.query("select * from test_1;");
+    const res1 = await connection.read("select * from test_1;");
     await expect(res1).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
 
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
-    const res2 = await connection.query("sELEct * frOM test_1;");
+    const res2 = await connection.read("sELEct * frOM test_1;");
     await expect(res2).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
   });
 
   test("parses tablename regardless of whitespace", async function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
-    const res1 = await connection.query("INSERT INTO test_1(colname) Values ('val6');");
+    const res1 = await connection.write("INSERT INTO test_1(colname) Values ('val6');");
     await expect(res1).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
 
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
-    const res2 = await connection.query("sELEct * frOM test_1;");
+    const res2 = await connection.read("sELEct * frOM test_1;");
     await expect(res2).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
   });
 
   test("parses tablename when inside double-quotes", async function () {
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
-    const res1 = await connection.query("INSERT INTO \"test_1\" (colname) Values ('val6');");
+    const res1 = await connection.write("INSERT INTO \"test_1\" (colname) Values ('val6');");
     await expect(res1).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
 
     fetch.mockResponseOnce(FetchSelectQuerySuccess);
 
-    const res2 = await connection.query("sELEct * frOM test_1;");
+    const res2 = await connection.read("sELEct * frOM test_1;");
     await expect(res2).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
   });
 });

--- a/test/runQuery.test.ts
+++ b/test/runQuery.test.ts
@@ -30,14 +30,14 @@ describe("read and write methods", function () {
     fetch.mockResponseOnce(FetchInsertQuerySuccess);
 
     const res = await connection.write("INSERT INTO test_1 (colname) values (val2);");
-    await expect(res).toEqual(undefined);
+    await expect(res).toEqual({"hash": "testhashinsertresponse"});
   });
 
   test("returns RPC result when update query succeeds", async function () {
     fetch.mockResponseOnce(FetchUpdateQuerySuccess);
 
     const res = await connection.write("UPDATE test_1 SET colname = val3 where colname = val2;");
-    await expect(res).toEqual(undefined);
+    await expect(res).toEqual({"hash": "testhashinsertresponse"});
   });
 
   test("maps arguments to correct RPC params", async function () {
@@ -51,41 +51,5 @@ describe("read and write methods", function () {
     await expect(payload.params[0]?.statement).toEqual(queryStaement);
     await expect(payload.params[0]).not.toHaveProperty("id");
     await expect(payload.params[0]).not.toHaveProperty("create_statement");
-  });
-
-  test("is case insensitive", async function () {
-    fetch.mockResponseOnce(FetchSelectQuerySuccess);
-
-    const res1 = await connection.read("select * from test_1;");
-    await expect(res1).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
-
-    fetch.mockResponseOnce(FetchSelectQuerySuccess);
-
-    const res2 = await connection.read("sELEct * frOM test_1;");
-    await expect(res2).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
-  });
-
-  test("parses tablename regardless of whitespace", async function () {
-    fetch.mockResponseOnce(FetchSelectQuerySuccess);
-
-    const res1 = await connection.write("INSERT INTO test_1(colname) Values ('val6');");
-    await expect(res1).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
-
-    fetch.mockResponseOnce(FetchSelectQuerySuccess);
-
-    const res2 = await connection.read("sELEct * frOM test_1;");
-    await expect(res2).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
-  });
-
-  test("parses tablename when inside double-quotes", async function () {
-    fetch.mockResponseOnce(FetchSelectQuerySuccess);
-
-    const res1 = await connection.write("INSERT INTO \"test_1\" (colname) Values ('val6');");
-    await expect(res1).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
-
-    fetch.mockResponseOnce(FetchSelectQuerySuccess);
-
-    const res2 = await connection.read("sELEct * frOM test_1;");
-    await expect(res2).toEqual({columns: [{name: "colname"}], rows: ["val1"]});
   });
 });


### PR DESCRIPTION
These updates include changes to the create api, and the splitting of the query method into a read, and a write method.

The thinking behind the changes to the create api is discussed here: https://www.notion.so/textile/Align-the-intention-more-directly-with-the-outcome-when-creating-tables-a82b38c7606942e48f9b3f6a033f516f#e1461d1d49574c92ab00d9d3e2674840

The thinking behind the splitting of `query` into `read` and `write` is discussed here: https://www.notion.so/textile/Allow-unauthenticated-reads-over-RPC-and-split-RunSQL-API-43f3890ec4d94755a319a27928e7efdd

One of the bigger related Validator PRs is here https://github.com/textileio/go-tableland/pull/114

A change to the Registry contract is needed to enable the new runSQL flow.  A potential for that change can be found here: https://github.com/tablelandnetwork/eth-tableland/pull/15

There are quite a few moving pieces here, and I didn't feel like it was straight forward to see if they are all working together.  Because of this I created a was to run a few "end-to-end", or "smoke-screen", tests here: https://github.com/textileio/local-tableland
