### PR TITLE
Get contract addresses from evm-tableland

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableland/sdk",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/sdk",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",
-        "@tableland/evm": "^1.0.0",
+        "@tableland/evm": "^2.0.1",
         "camelcase": "^6.3.0",
         "ethers": "^5.5.2",
         "siwe": "^1.1.6"
@@ -3292,9 +3292,9 @@
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "node_modules/@tableland/evm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-1.1.0.tgz",
-      "integrity": "sha512-J4UDzWKi3YepEBWMY0pAi8hLHQqR3+ikatHzAbVTtEctKzylx6vj7mPwn2tdzwIiue6ffIPYeoZuZoloO8JYhg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-2.0.1.tgz",
+      "integrity": "sha512-KRsLZEoFP4PGB1z94/pF/ahWS1Inv5NQMvbBCDjhXw+vrixcz001UhWCh5s7z8dovm+d7kdHylr0mnEkhYKQIA==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -13509,9 +13509,9 @@
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "@tableland/evm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-1.1.0.tgz",
-      "integrity": "sha512-J4UDzWKi3YepEBWMY0pAi8hLHQqR3+ikatHzAbVTtEctKzylx6vj7mPwn2tdzwIiue6ffIPYeoZuZoloO8JYhg=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-2.0.1.tgz",
+      "integrity": "sha512-KRsLZEoFP4PGB1z94/pF/ahWS1Inv5NQMvbBCDjhXw+vrixcz001UhWCh5s7z8dovm+d7kdHylr0mnEkhYKQIA=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/sdk",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A TypeScript/JavaScript library for creating and querying Tables on the Tableland network.",
   "repository": "https://github.com/tablelandnetwork/js-tableland",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "siwe": "^1.1.6",
     "camelcase": "^6.3.0",
     "@stablelib/base64": "^1.0.1",
-    "@tableland/evm": "^2.0.0",
+    "@tableland/evm": "^2.0.1",
     "ethers": "^5.5.2"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "siwe": "^1.1.6",
     "camelcase": "^6.3.0",
     "@stablelib/base64": "^1.0.1",
-    "@tableland/evm": "^1.0.0",
+    "@tableland/evm": "^2.0.0",
     "ethers": "^5.5.2"
   },
   "contributors": [

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -44,11 +44,6 @@ export async function connect(options: ConnectOptions): Promise<Connection> {
   if (!["testnet", "staging", "custom"].includes(network)) {
     throw new Error("unsupported network specified");
   }
-  const host =
-    options.host ??
-    `https://${
-      network === "testnet" ? "testnetv2" : "staging"
-    }.tableland.network`;
 
   const signer = options.signer;
   if (signer && signer.provider) {
@@ -75,6 +70,7 @@ export async function connect(options: ConnectOptions): Promise<Connection> {
     );
   }
 
+  const host = options.host ?? info.host;
   const chainId = options.chainId ?? info.chainId;
   // We can override the contract address here for any supported network
   const contract = options.contract ?? info.contract;

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -47,21 +47,21 @@ export const SUPPORTED_CHAINS: Record<ChainName, SupportedChain> = {
     phrase: "Ethereum Goerli",
     chainId: 5,
     contract: proxies["ethereum-goerli"],
-    host: "https://testnet.tableland.network"
+    host: "https://testnet.tableland.network",
   },
   "optimism-kovan": {
     name: "optimism-kovan",
     phrase: "Optimism Kovan",
     chainId: 69,
     contract: proxies["optimism-kovan"],
-    host: "https://testnet.tableland.network"
+    host: "https://testnet.tableland.network",
   },
   "polygon-mumbai": {
     name: "maticmum",
     phrase: "Polygon Testnet",
     chainId: 80001,
     contract: proxies["polygon-mumbai"],
-    host: "https://testnet.tableland.network"
+    host: "https://testnet.tableland.network",
   },
   // staging
   "optimism-kovan-staging": {
@@ -69,16 +69,16 @@ export const SUPPORTED_CHAINS: Record<ChainName, SupportedChain> = {
     phrase: "Optimism Kovan",
     chainId: 69,
     contract: proxies["optimism-kovan-staging"],
-    host: "https://staging.tableland.network"
+    host: "https://staging.tableland.network",
   },
   // Testing
   custom: {
     name: "localhost",
     phrase: "Custom Chain",
     chainId: 31337, // Default to using hardhat chainId
-    // If building locally you can put your contract address here or use the contract connection option
-    contract: "",
-    host: ""
+    // If building locally you can put your contract address and host here or use the contract connection option
+    contract: "", // e.g. "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
+    host: "", // e.g. "http://localhost:8080"
   },
 };
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,5 +1,6 @@
 import { Signer, ethers } from "ethers";
 import camelCase from "camelcase";
+import proxies from "@tableland/evm/proxies.js";
 
 declare let globalThis: any;
 
@@ -44,26 +45,26 @@ export const SUPPORTED_CHAINS: Record<ChainName, SupportedChain> = {
     name: "goerli",
     phrase: "Ethereum Goerli",
     chainId: 5,
-    contract: "0xa4b0729f02C6dB01ADe92d247b7425953d1DbA25",
+    contract: proxies["ethereum-goerli"],
   },
   "optimism-kovan": {
     name: "optimism-kovan",
     phrase: "Optimism Kovan",
     chainId: 69,
-    contract: "0xf9C3530C03D335a00163382366a72cc1Ebbd39fF",
+    contract: proxies["optimism-kovan"],
   },
   "polygon-mumbai": {
     name: "maticmum",
     phrase: "Polygon Testnet",
     chainId: 80001,
-    contract: "0x70364D26743851d4FE43eCb065811402D06bf4AD",
+    contract: proxies["polygon-mumbai"],
   },
   // staging
   "optimism-kovan-staging": {
     name: "optimism-kovan",
     phrase: "Optimism Kovan",
     chainId: 69,
-    contract: "0x322F01e81c38B4211529f334864fA630F6aeA408",
+    contract: proxies["optimism-kovan-staging"],
   },
   // Testing
   custom: {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -37,6 +37,7 @@ export interface SupportedChain {
   phrase: string;
   chainId: number;
   contract: string;
+  host: string;
 }
 
 export const SUPPORTED_CHAINS: Record<ChainName, SupportedChain> = {
@@ -46,18 +47,21 @@ export const SUPPORTED_CHAINS: Record<ChainName, SupportedChain> = {
     phrase: "Ethereum Goerli",
     chainId: 5,
     contract: proxies["ethereum-goerli"],
+    host: "https://testnet.tableland.network"
   },
   "optimism-kovan": {
     name: "optimism-kovan",
     phrase: "Optimism Kovan",
     chainId: 69,
     contract: proxies["optimism-kovan"],
+    host: "https://testnet.tableland.network"
   },
   "polygon-mumbai": {
     name: "maticmum",
     phrase: "Polygon Testnet",
     chainId: 80001,
     contract: proxies["polygon-mumbai"],
+    host: "https://testnet.tableland.network"
   },
   // staging
   "optimism-kovan-staging": {
@@ -65,6 +69,7 @@ export const SUPPORTED_CHAINS: Record<ChainName, SupportedChain> = {
     phrase: "Optimism Kovan",
     chainId: 69,
     contract: proxies["optimism-kovan-staging"],
+    host: "https://staging.tableland.network"
   },
   // Testing
   custom: {
@@ -73,6 +78,7 @@ export const SUPPORTED_CHAINS: Record<ChainName, SupportedChain> = {
     chainId: 31337, // Default to using hardhat chainId
     // If building locally you can put your contract address here or use the contract connection option
     contract: "",
+    host: ""
   },
 };
 


### PR DESCRIPTION
Fixes #65

This won't be possible until evm-tableland has published a version that is exporting the addresses