### PR TITLE
Correctly get deployed registry contract addresses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",
-        "@tableland/evm": "^2.0.1",
+        "@tableland/evm": "^2.0.2",
         "camelcase": "^6.3.0",
         "ethers": "^5.5.2",
         "siwe": "^1.1.6"
@@ -3292,9 +3292,9 @@
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "node_modules/@tableland/evm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-2.0.1.tgz",
-      "integrity": "sha512-KRsLZEoFP4PGB1z94/pF/ahWS1Inv5NQMvbBCDjhXw+vrixcz001UhWCh5s7z8dovm+d7kdHylr0mnEkhYKQIA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-2.0.2.tgz",
+      "integrity": "sha512-ZzYEfqQC1blUS0Ao5oGnxb4cDZt90jVJ3JtIAhcRJd39HGVAo6B0wA2pFreb5yfveT+Jji5HzM3OP97NK/71ew==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -13509,9 +13509,9 @@
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "@tableland/evm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-2.0.1.tgz",
-      "integrity": "sha512-KRsLZEoFP4PGB1z94/pF/ahWS1Inv5NQMvbBCDjhXw+vrixcz001UhWCh5s7z8dovm+d7kdHylr0mnEkhYKQIA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-2.0.2.tgz",
+      "integrity": "sha512-ZzYEfqQC1blUS0Ao5oGnxb4cDZt90jVJ3JtIAhcRJd39HGVAo6B0wA2pFreb5yfveT+Jji5HzM3OP97NK/71ew=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableland/sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/sdk",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "siwe": "^1.1.6",
     "camelcase": "^6.3.0",
     "@stablelib/base64": "^1.0.1",
-    "@tableland/evm": "^2.0.1",
+    "@tableland/evm": "^2.0.2",
     "ethers": "^5.5.2"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A TypeScript/JavaScript library for creating and querying Tables on the Tableland network.",
   "repository": "https://github.com/tablelandnetwork/js-tableland",
   "license": "MIT",

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,6 +1,6 @@
 import { Signer, ethers } from "ethers";
 import camelCase from "camelcase";
-import proxies from "@tableland/evm/proxies.js";
+import { proxies } from "@tableland/evm/proxies.js";
 
 declare let globalThis: any;
 


### PR DESCRIPTION
This fixes an issue that was preventing the sdk from connecting to the correct evm contract address