### PR TITLE
Confirm contract events are materialized

### DIFF
--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -76,4 +76,5 @@ export interface Connection {
   hash: (query: string) => Promise<StructureHashResult>;
   receipt: (txnHash: string) => Promise<ReceiptResult | undefined>;
   siwe: () => Promise<Token>;
+  onMaterialize: (txnHash: string) => Promise<ReceiptResult>;
 }

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -49,6 +49,12 @@ export interface MethodOptions {
   prefix?: string;
   skipConfirm?: boolean;
   rpcRelay?: boolean;
+  timeout?: number;
+}
+
+export interface MaterializeOptions {
+  timeout?: number;
+  rate?: number;
 }
 
 export interface Connection {
@@ -82,5 +88,8 @@ export interface Connection {
   hash: (query: string) => Promise<StructureHashResult>;
   receipt: (txnHash: string) => Promise<ReceiptResult | undefined>;
   siwe: () => Promise<Token>;
-  onMaterialize: (txnHash: string) => Promise<ReceiptResult>;
+  onMaterialize: (
+    txnHash: string,
+    options?: MaterializeOptions
+  ) => Promise<ReceiptResult>;
 }

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -45,6 +45,12 @@ export interface CreateTableReceipt {
   blockNumber: number;
 }
 
+export interface MethodOptions {
+  prefix?: string;
+  skipConfirm?: boolean;
+  rpcRelay?: boolean;
+}
+
 export interface Connection {
   token?: Token;
   signer?: Signer;

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -52,7 +52,7 @@ export interface MethodOptions {
   timeout?: number;
 }
 
-export interface MaterializeOptions {
+export interface ConfirmOptions {
   timeout?: number;
   rate?: number;
 }
@@ -88,8 +88,8 @@ export interface Connection {
   hash: (query: string) => Promise<StructureHashResult>;
   receipt: (txnHash: string) => Promise<ReceiptResult | undefined>;
   siwe: () => Promise<Token>;
-  onMaterialize: (
+  onConfirm: (
     txnHash: string,
-    options?: MaterializeOptions
+    options?: ConfirmOptions
   ) => Promise<ReceiptResult>;
 }

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -6,7 +6,12 @@ import { create } from "./create.js";
 import { hash } from "./hash.js";
 import { siwe } from "./siwe.js";
 import { receipt } from "./tableland-calls.js";
-import { SUPPORTED_CHAINS, NetworkName, ChainName, onMaterialize } from "./util.js";
+import {
+  SUPPORTED_CHAINS,
+  NetworkName,
+  ChainName,
+  onMaterialize,
+} from "./util.js";
 import { Connection } from "./connection.js";
 
 /**
@@ -115,7 +120,7 @@ export async function connect(options: ConnectOptions): Promise<Connection> {
     },
     get onMaterialize() {
       return onMaterialize;
-    }
+    },
   };
 
   return connectionObject;

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -6,7 +6,7 @@ import { create } from "./create.js";
 import { hash } from "./hash.js";
 import { siwe } from "./siwe.js";
 import { receipt } from "./tableland-calls.js";
-import { SUPPORTED_CHAINS, NetworkName, ChainName } from "./util.js";
+import { SUPPORTED_CHAINS, NetworkName, ChainName, onMaterialize } from "./util.js";
 import { Connection } from "./connection.js";
 
 /**
@@ -113,6 +113,9 @@ export async function connect(options: ConnectOptions): Promise<Connection> {
     get siwe() {
       return siwe;
     },
+    get onMaterialize() {
+      return onMaterialize;
+    }
   };
 
   return connectionObject;

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -6,12 +6,7 @@ import { create } from "./create.js";
 import { hash } from "./hash.js";
 import { siwe } from "./siwe.js";
 import { receipt } from "./tableland-calls.js";
-import {
-  SUPPORTED_CHAINS,
-  NetworkName,
-  ChainName,
-  onMaterialize,
-} from "./util.js";
+import { SUPPORTED_CHAINS, NetworkName, ChainName, onConfirm } from "./util.js";
 import { Connection } from "./connection.js";
 
 /**
@@ -118,8 +113,8 @@ export async function connect(options: ConnectOptions): Promise<Connection> {
     get siwe() {
       return siwe;
     },
-    get onMaterialize() {
-      return onMaterialize;
+    get onConfirm() {
+      return onConfirm;
     },
   };
 

--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -41,7 +41,7 @@ export async function create(
   const name = `${prefix}_${chainId}_${tableId}`;
 
   if (!skipConfirm) {
-    await this.onMaterialize(txnHash, { timeout: timeout });
+    await this.onConfirm(txnHash, { timeout: timeout });
   }
 
   return { tableId, prefix, chainId, txnHash, blockNumber, name };

--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -6,9 +6,8 @@ import { getPrefix, getTimeout, shouldSkipConfirm } from "./util.js";
 
 /**
  * Registers an NFT with the Tableland Ethereum smart contract, then uses that to register
- * a new Table on Tableland. This method returns after the tableId has been minted, but not
- * nessessarily before the Tableland network has picked up the CREATE TABLE event. Use
- * the `receipt` method on the returned `txnHash` to check the status of the table.
+ * a new Table on Tableland. This method returns after the table has been confirmed in the
+ * Validator unless the `skipConfirm` option is set to true
  * @param {string} schema SQL table schema.
  * @returns {string} A Promise that resolves to a pending table creation receipt.
  */

--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -17,7 +17,7 @@ export async function create(
   schema: string,
   // TODO: changing how this function is called would require a major version bump
   //       making it polymophic lets us keep it in the current major verision.
-  //       when bump major remember to change this arg to only be `MethodOptions`
+  //       when bump major consider changing this arg to only be `MethodOptions`
   options?: MethodOptions | string
 ): Promise<CreateTableReceipt> {
   const { chainId } = this.options;

--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -1,8 +1,8 @@
 import { Connection, CreateTableReceipt } from "./connection.js";
 import * as tablelandCalls from "./tableland-calls.js";
 import { registerTable } from "./eth-calls.js";
-// import { userCreatesToken } from "./token.js";
 import { BigNumber } from "ethers";
+
 /**
  * Registers an NFT with the Tableland Ethereum smart contract, then uses that to register
  * a new Table on Tableland. This method returns after the tableId has been minted, but not
@@ -30,5 +30,8 @@ export async function create(
   const blockNumber = txn.blockNumber;
   const tableId: BigNumber | undefined = event?.args?.tableId;
   const name = `${prefix}_${chainId}_${tableId}`;
+
+  await this.onMaterialize(txnHash);
+
   return { tableId, prefix, chainId, txnHash, blockNumber, name };
 }

--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -1,7 +1,8 @@
-import { Connection, CreateTableReceipt } from "./connection.js";
+import { BigNumber } from "ethers";
+import { Connection, CreateTableReceipt, MethodOptions } from "./connection.js";
 import * as tablelandCalls from "./tableland-calls.js";
 import { registerTable } from "./eth-calls.js";
-import { BigNumber } from "ethers";
+import { getPrefix, shouldSkipConfirm } from "./util.js";
 
 /**
  * Registers an NFT with the Tableland Ethereum smart contract, then uses that to register
@@ -14,9 +15,15 @@ import { BigNumber } from "ethers";
 export async function create(
   this: Connection,
   schema: string,
-  prefix: string = ""
+  // TODO: changing how this function is called would require a major version bump
+  //       making it polymophic lets us keep it in the current major verision.
+  //       when bump major remember to change this arg to only be `MethodOptions`
+  options?: MethodOptions | string
 ): Promise<CreateTableReceipt> {
   const { chainId } = this.options;
+  const prefix = getPrefix(options);
+  const skipConfirm = shouldSkipConfirm(options);
+
   const query = `CREATE TABLE ${prefix}_${chainId} (${schema});`;
   // This "dryrun" is done to validate that the query statement is considered valid.
   // We check this before minting the token, so the caller won't succeed at minting a token
@@ -31,7 +38,7 @@ export async function create(
   const tableId: BigNumber | undefined = event?.args?.tableId;
   const name = `${prefix}_${chainId}_${tableId}`;
 
-  await this.onMaterialize(txnHash);
+  if (!skipConfirm) await this.onMaterialize(txnHash);
 
   return { tableId, prefix, chainId, txnHash, blockNumber, name };
 }

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -3,7 +3,6 @@
  * @param query A SQL query to run
  * @returns If read query, result-set. If write query, nothing.
  */
-
 import { ReadQueryResult, WriteQueryResult, Connection } from "./connection.js";
 import * as tablelandCalls from "./tableland-calls.js";
 import { runSql } from "./eth-calls.js";
@@ -33,6 +32,7 @@ export async function write(
   const { tableId } = await tablelandCalls.validateWriteQuery.call(this, query);
 
   const txn = await runSql.call(this, tableId, query);
+  await this.onMaterialize(txn.transactionHash);
 
   return { hash: txn.transactionHash };
 }

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -25,7 +25,10 @@ export async function write(
   query: string
 ): Promise<WriteQueryResult> {
   if (this.options.rpcRelay) {
-    return await tablelandCalls.write.call(this, query);
+    const response = await tablelandCalls.write.call(this, query);
+    await this.onMaterialize(response.hash);
+
+    return response;
   }
 
   // ask the Validator if this query is valid, and get the tableId for use in SC call

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -34,7 +34,7 @@ export async function write(
   const skipConfirm = shouldSkipConfirm(options);
   if (this.options.rpcRelay || options?.rpcRelay) {
     const response = await tablelandCalls.write.call(this, query);
-    if (!skipConfirm) await this.onMaterialize(response.hash);
+    if (!skipConfirm) await this.onConfirm(response.hash);
 
     return response;
   }
@@ -43,7 +43,7 @@ export async function write(
   const { tableId } = await tablelandCalls.validateWriteQuery.call(this, query);
 
   const txn = await runSql.call(this, tableId, query);
-  if (!skipConfirm) await this.onMaterialize(txn.transactionHash);
+  if (!skipConfirm) await this.onConfirm(txn.transactionHash);
 
   return { hash: txn.transactionHash };
 }

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -3,9 +3,15 @@
  * @param query A SQL query to run
  * @returns If read query, result-set. If write query, nothing.
  */
-import { ReadQueryResult, WriteQueryResult, Connection } from "./connection.js";
+import {
+  ReadQueryResult,
+  WriteQueryResult,
+  Connection,
+  MethodOptions,
+} from "./connection.js";
 import * as tablelandCalls from "./tableland-calls.js";
 import { runSql } from "./eth-calls.js";
+import { shouldSkipConfirm } from "./util.js";
 
 export function resultsToObjects({ rows, columns }: ReadQueryResult) {
   return rows.map((row: any[]) =>
@@ -22,11 +28,13 @@ export async function read(
 
 export async function write(
   this: Connection,
-  query: string
+  query: string,
+  options?: MethodOptions
 ): Promise<WriteQueryResult> {
-  if (this.options.rpcRelay) {
+  const skipConfirm = shouldSkipConfirm(options);
+  if (this.options.rpcRelay || options?.rpcRelay) {
     const response = await tablelandCalls.write.call(this, query);
-    await this.onMaterialize(response.hash);
+    if (!skipConfirm) await this.onMaterialize(response.hash);
 
     return response;
   }
@@ -35,7 +43,7 @@ export async function write(
   const { tableId } = await tablelandCalls.validateWriteQuery.call(this, query);
 
   const txn = await runSql.call(this, tableId, query);
-  await this.onMaterialize(txn.transactionHash);
+  if (!skipConfirm) await this.onMaterialize(txn.transactionHash);
 
   return { hash: txn.transactionHash };
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,7 +1,7 @@
 import { Signer, ethers } from "ethers";
 import camelCase from "camelcase";
 import { proxies } from "@tableland/evm/proxies.js";
-import { Connection, ReceiptResult } from "./connection.js";
+import { Connection, ReceiptResult, MethodOptions } from "./connection.js";
 
 declare let globalThis: any;
 
@@ -155,4 +155,20 @@ export async function onMaterialize(
   }
 
   return table;
+}
+
+// TODO: this could be removed if we bump major version
+export function getPrefix(options?: MethodOptions | string): string {
+  if (typeof options === "undefined") return "";
+  if (typeof options === "string") return options;
+  return options.prefix || "";
+}
+
+// TODO: this could be removed if we bump major version
+export function shouldSkipConfirm(
+  options?: MethodOptions | string | undefined
+): boolean {
+  if (typeof options === "undefined") return false;
+  if (typeof options === "string") return false;
+  return !!options.skipConfirm;
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -5,7 +5,7 @@ import {
   Connection,
   ReceiptResult,
   MethodOptions,
-  MaterializeOptions,
+  ConfirmOptions,
 } from "./connection.js";
 
 declare let globalThis: any;
@@ -118,10 +118,10 @@ export function camelCaseKeys(obj: any): any {
 // Helper function to enable waiting until a transaction has been materialized by the Validator.
 // Uses dirty polling with exponential backoff up to a maximum timeout.
 // Potential optimization could be had if the Validator supported Websockets or long-poling for receipts
-export async function onMaterialize(
+export async function onConfirm(
   this: Connection,
   txnHash: string,
-  options?: MaterializeOptions
+  options?: ConfirmOptions
 ): Promise<ReceiptResult> {
   // default timeout 2 minutes
   // TODO: move default to a single spot

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,7 +1,12 @@
 import { Signer, ethers } from "ethers";
 import camelCase from "camelcase";
 import { proxies } from "@tableland/evm/proxies.js";
-import { Connection, ReceiptResult, MethodOptions } from "./connection.js";
+import {
+  Connection,
+  ReceiptResult,
+  MethodOptions,
+  MaterializeOptions,
+} from "./connection.js";
 
 declare let globalThis: any;
 
@@ -41,11 +46,6 @@ export interface SupportedChain {
   contract: string;
   host: string;
   rpcRelay: boolean;
-}
-
-interface MaterializeOptions {
-  timeout?: number;
-  rate?: number;
 }
 
 export const SUPPORTED_CHAINS: Record<ChainName, SupportedChain> = {
@@ -124,7 +124,9 @@ export async function onMaterialize(
   options?: MaterializeOptions
 ): Promise<ReceiptResult> {
   // default timeout 2 minutes
+  // TODO: move default to a single spot
   const timeout = options?.timeout ?? 120 * 1000;
+
   // determines how often to check for materialization before timeout
   const rate = options?.rate ?? 1500;
   const start = Date.now();
@@ -171,4 +173,15 @@ export function shouldSkipConfirm(
   if (typeof options === "undefined") return false;
   if (typeof options === "string") return false;
   return !!options.skipConfirm;
+}
+
+export function getTimeout(
+  options: MethodOptions | string | undefined,
+  deflt: number
+): number {
+  if (typeof options === "undefined") return deflt;
+  if (typeof options === "string") return deflt;
+  if (typeof options.timeout !== "number") return deflt;
+
+  return options.timeout;
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -116,8 +116,9 @@ export function camelCaseKeys(obj: any): any {
 }
 
 // Helper function to enable waiting until a transaction has been materialized by the Validator.
-// Uses dirty polling with exponential backoff up to a maximum timeout.
-// Potential optimization could be had if the Validator supported Websockets or long-poling for receipts
+// Uses simple polling with exponential backoff up to a maximum timeout.
+// Potential optimization could be had if the Validator supports subscribing to transaction
+// receipts via Websockets or long-poling in the future
 export async function onConfirm(
   this: Connection,
   txnHash: string,

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -7,8 +7,8 @@ import { connect, NetworkName, SUPPORTED_CHAINS } from "../src/main";
 import { ConnectOptions } from "../src/lib/connector.js";
 import {
   FetchCreateDryRunSuccess,
-  FetchCreateTableOnTablelandSuccess,
   FetchHashTableSuccess,
+  FetchReceiptExists,
 } from "./fauxFetch";
 
 describe("connect function", function () {
@@ -61,7 +61,7 @@ describe("connect function", function () {
     });
 
     fetch.mockResponseOnce(FetchCreateDryRunSuccess);
-    fetch.mockResponseOnce(FetchCreateTableOnTablelandSuccess);
+    fetch.mockResponseOnce(FetchReceiptExists);
 
     await connection.create("id int primary key, val text", "hello");
 

--- a/test/createTable.test.ts
+++ b/test/createTable.test.ts
@@ -57,4 +57,15 @@ describe("create method", function () {
     const txReceipt = await connection.create("id int primary key, val text", { skipConfirm: true });
     await expect(txReceipt.tableId._hex).toEqual("0x015");
   });
+
+  test("Create table options enable setting timeout for materialization", async function () {
+    fetch.mockResponseOnce(FetchCreateDryRunSuccess);
+    fetch.mockResponseOnce(FetchReceiptNone);
+    fetch.mockResponseOnce(FetchReceiptNone);
+    fetch.mockResponseOnce(FetchReceiptNone);
+
+    await expect(async function () {
+      await connection.create("id int primary key, val text", { timeout: 2000 /* 2 seconds */ })
+    }).rejects.toThrow(/timeout exceeded: could not get transaction receipt:/);
+  }, 5000 /* 5 seconds */);
 });

--- a/test/createTable.test.ts
+++ b/test/createTable.test.ts
@@ -50,4 +50,11 @@ describe("create method", function () {
     const txReceipt = await connection.create("id int primary key, val text");
     await expect(txReceipt.tableId._hex).toEqual("0x015");
   });
+
+  test("Create table options enable not waiting to return until after materialization", async function () {
+    fetch.mockResponseOnce(FetchCreateDryRunSuccess);
+
+    const txReceipt = await connection.create("id int primary key, val text", { skipConfirm: true });
+    await expect(txReceipt.tableId._hex).toEqual("0x015");
+  });
 });

--- a/test/fauxFetch.ts
+++ b/test/fauxFetch.ts
@@ -132,35 +132,41 @@ export const FetchHashTableSuccess = async () => {
 };
 
 export const FetchHashTableError = async () => {
-  return JSON.stringify({
-    jsonrpc: "2.0",
-    id: 1,
-    error: {
-      code: -32000,
-      message: "TEST ERROR: invalid sql near 123",
-    },
-  });
+  return {
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32000,
+        message: "TEST ERROR: invalid sql near 123",
+      },
+    })
+  };
 };
 
 export const FetchReceiptExists = async () => {
-  return JSON.stringify({
-    jsonrpc: "2.0",
-    id: 1,
-    result: {
-      receipt: {
-        chainId: 5,
-        txnHash: "0xc3e7d1e81b59556f414a5f5c23760eb61b4bfaa18150d924d7d3b334941dbecd",
-        blockNumber: 1000,
-        tableId: '2',
+  return {
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        receipt: {
+          chainId: 5,
+          txnHash: "0xc3e7d1e81b59556f414a5f5c23760eb61b4bfaa18150d924d7d3b334941dbecd",
+          blockNumber: 1000,
+          tableId: '2',
+        }
       }
-    }
-  });
+    })
+  };
 };
 
 export const FetchReceiptNone = async () => {
-  return JSON.stringify({
-    jsonrpc: "2.0",
-    id: 1,
-    result: {}
-  });
+  return {
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {},
+    }),
+  };
 };

--- a/test/mock_modules/evm.js
+++ b/test/mock_modules/evm.js
@@ -8,7 +8,7 @@ module.exports = {
               return {
                 events: [
                   {},
-                  { args: { tableId: { _hex: "0x015", type: "BigNumber" }}},
+                  { args: { tableId: { _hex: "0x015", type: "BigNumber" } } },
                 ],
                 transactionHash: "0x017"
               };

--- a/test/mock_modules/evm.js
+++ b/test/mock_modules/evm.js
@@ -8,8 +8,9 @@ module.exports = {
               return {
                 events: [
                   {},
-                  { args: { tableId: { _hex: "0x015", type: "BigNumber" } } },
+                  { args: { tableId: { _hex: "0x015", type: "BigNumber" }}},
                 ],
+                transactionHash: "0x017"
               };
             },
           };

--- a/test/runQuery.test.ts
+++ b/test/runQuery.test.ts
@@ -36,6 +36,7 @@ describe("read and write methods", function () {
 
   test("returns RPC result when insert query succeeds", async function () {
     fetch.mockResponseOnce(FetchInsertQuerySuccess);
+    fetch.mockResponseOnce(FetchReceiptExists);
 
     const res = await connection.write(
       "INSERT INTO test_1 (colname) values (val2);"
@@ -45,6 +46,7 @@ describe("read and write methods", function () {
 
   test("returns RPC result when update query succeeds", async function () {
     fetch.mockResponseOnce(FetchUpdateQuerySuccess);
+    fetch.mockResponseOnce(FetchReceiptExists);
 
     const res = await connection.write(
       "UPDATE test_1 SET colname = val3 where colname = val2;"

--- a/test/runQuery.test.ts
+++ b/test/runQuery.test.ts
@@ -1,7 +1,7 @@
 import fetch from "jest-fetch-mock";
 import { connect, resultsToObjects } from "../src/main";
 import {
-  FetchDirectRunSQLSuccess,
+  FetchReceiptExists,
   FetchSelectQuerySuccess,
   FetchInsertQuerySuccess,
   FetchUpdateQuerySuccess,
@@ -54,7 +54,7 @@ describe("read and write methods", function () {
 
   test("returns transaction receipt when contract is called directly", async function () {
     fetch.mockResponseOnce(FetchValidateWriteQuery);
-    fetch.mockResponseOnce(FetchDirectRunSQLSuccess);
+    fetch.mockResponseOnce(FetchReceiptExists);
 
     const connection = await connect({
       network: "testnet",

--- a/test/runQuery.test.ts
+++ b/test/runQuery.test.ts
@@ -54,6 +54,16 @@ describe("read and write methods", function () {
     await expect(res).toEqual({ hash: "testhashinsertresponse" });
   });
 
+  test("write options enable not waiting to return until after materialization", async function () {
+    fetch.mockResponseOnce(FetchUpdateQuerySuccess);
+
+    const res = await connection.write(
+      "UPDATE test_1 SET colname = val3 where colname = val2;",
+      { skipConfirm: true }
+    );
+    await expect(res).toEqual({ hash: "testhashinsertresponse" });
+  });
+
   test("returns transaction receipt when contract is called directly", async function () {
     fetch.mockResponseOnce(FetchValidateWriteQuery);
     fetch.mockResponseOnce(FetchReceiptExists);


### PR DESCRIPTION
### Overview
`create` and `write` methods call smart contract methods (with or without relay) which eventually materialize into table state in Validators within Tableland.  As a developer, you are currently forced to roll your own way to discover when those changes had been consumed and materialized by Validators.  The changes in this PR make the`write` and `create` methods default to waiting to resolve until the SDK's connected Validator has materialized the transaction's sql statements.

This is accomplished through simple(dirty) polling the Validator via the `receipt` method until the receipt exists or a timeout is reached.  The polling rate is calculated with exponential backoff, and then once more at the after expiration of the timeout.

### More Details
As well as defaulting to waiting for materialization, this introduces the ability to set behavior via options.
The `write` method now takes an optional second argument that is an options Object. 
The `create` method is now polymorphic.  The second argument can still be a String to be used as a table name prefix, or it can be an options Object.

Available options:
 - `skipConfirm`: Default is false, and if set to true the method returns as soon as it gets the smart contract transaction hash.  If set to true, the method waits for the Validator to confirm materialization up to `timeout`
 - `prefix`:  Only available to the `create` method.  Default is ""
 - `timeout`: Default is 120000 (2 minutes). The maximum amount of time in milliseconds the caller is willing to poll the Validator waiting to confirm the materialization of the changes.

### Notes and Thoughts
The `skipConfirm` option being set to true will probably make sense for SDK users who are on L1 mainnets.  I considered having the default value be set differently for each Tableland network, but I feel that might not make sense for devs who are working in a testnet as a way to **test** (literally) a future mainnet application.

Ref to the Objective:  https://www.notion.so/textile/Handle-receipt-confirmations-in-JS-SDK-82da86b6184f4472a42d697b5ef91f9f