### PR TITLE
Fix #76, ensure wallet and tableland share chain

### DIFF
--- a/src/lib/check-network.ts
+++ b/src/lib/check-network.ts
@@ -1,4 +1,5 @@
 import { Connection } from "./connection.js";
+import { getSigner } from "./util.js";
 
 /**
  * Ensures that a connection signer's network and the connection's tableland network
@@ -8,8 +9,10 @@ import { Connection } from "./connection.js";
  * @returns {string} A Promise that resolves to undefined.
  */
 export async function checkNetwork(this: Connection): Promise<void> {
-  if (!(this.signer && this.signer.provider)) {
-    throw new Error("signer and provider are required");
+  this.signer = this.signer ?? (await getSigner());
+
+  if (!this.signer.provider) {
+    throw new Error("provider is required");
   }
 
   const { chainId } = await this.signer.provider.getNetwork();

--- a/src/lib/checkNetwork.ts
+++ b/src/lib/checkNetwork.ts
@@ -1,0 +1,23 @@
+import { Connection } from "./connection.js";
+
+/**
+ * Ensures that a connection signer's network and the connection's tableland network
+ * are using the same chain.
+ * If this isn't called before smart contract method calls there is a chance the
+ * transaction will happen on the wrong chain which results in unintended behaviour
+ * @returns {string} A Promise that resolves to undefined.
+ */
+export async function checkNetwork(this: Connection): Promise<void> {
+  if (!(this.signer && this.signer.provider)) {
+    throw new Error(
+      "signer and provider are required"
+    );
+  }
+
+  const { chainId } = await this.signer.provider.getNetwork();
+  if (!this.options.chainId || chainId !== this.options.chainId) {
+    throw new Error(
+      "provider chain and tableland network mismatch. Switch your wallet connection and reconnect"
+    );
+  }
+}

--- a/src/lib/checkNetwork.ts
+++ b/src/lib/checkNetwork.ts
@@ -9,9 +9,7 @@ import { Connection } from "./connection.js";
  */
 export async function checkNetwork(this: Connection): Promise<void> {
   if (!(this.signer && this.signer.provider)) {
-    throw new Error(
-      "signer and provider are required"
-    );
+    throw new Error("signer and provider are required");
   }
 
   const { chainId } = await this.signer.provider.getNetwork();

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -76,4 +76,5 @@ export interface Connection {
   hash: (query: string) => Promise<StructureHashResult>;
   receipt: (txnHash: string) => Promise<ReceiptResult | undefined>;
   siwe: () => Promise<Token>;
+  checkNetwork: () => Promise<void>;
 }

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -7,7 +7,7 @@ import { hash } from "./hash.js";
 import { siwe } from "./siwe.js";
 import { receipt } from "./tableland-calls.js";
 import { SUPPORTED_CHAINS, NetworkName, ChainName } from "./util.js";
-import { checkNetwork } from "./checkNetwork.js";
+import { checkNetwork } from "./check-network.js";
 import { Connection } from "./connection.js";
 
 /**

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -7,6 +7,7 @@ import { hash } from "./hash.js";
 import { siwe } from "./siwe.js";
 import { receipt } from "./tableland-calls.js";
 import { SUPPORTED_CHAINS, NetworkName, ChainName } from "./util.js";
+import { checkNetwork } from "./checkNetwork.js";
 import { Connection } from "./connection.js";
 
 /**
@@ -37,7 +38,7 @@ export interface ConnectOptions {
  * @param options Options to control client connection.
  * @returns Promise that resolves to a Connection object.
  */
-export async function connect(options: ConnectOptions): Promise<Connection> {
+export function connect(options: ConnectOptions): Connection {
   const network = options.network ?? "testnet";
   let chain = options.chain ?? "ethereum-goerli";
   if (network === "custom" && !options.host) {
@@ -48,22 +49,6 @@ export async function connect(options: ConnectOptions): Promise<Connection> {
   }
 
   const signer = options.signer;
-  if (signer && signer.provider) {
-    // Set params with provider network info if not explicitly given in options
-    if (!options.chain && !options.chainId) {
-      const { name } = await signer.provider.getNetwork();
-      const found = Object.entries(SUPPORTED_CHAINS).find(
-        ([, chainEntry]) => chainEntry.name === name
-      );
-      if (found) {
-        chain = found[0] as ChainName;
-      } else {
-        throw new Error(
-          "proivder chain mismatch. Switch your wallet connection and reconnect"
-        );
-      }
-    }
-  }
 
   const info = SUPPORTED_CHAINS[chain];
   if (!info && !options.chainId) {
@@ -112,6 +97,9 @@ export async function connect(options: ConnectOptions): Promise<Connection> {
     },
     get siwe() {
       return siwe;
+    },
+    get checkNetwork() {
+      return checkNetwork;
     },
   };
 

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -40,7 +40,7 @@ export interface ConnectOptions {
  */
 export function connect(options: ConnectOptions): Connection {
   const network = options.network ?? "testnet";
-  let chain = options.chain ?? "ethereum-goerli";
+  const chain = options.chain ?? "ethereum-goerli";
   if (network === "custom" && !options.host) {
     throw new Error('`host` must be provided if using "custom" network');
   }

--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -16,6 +16,10 @@ export async function create(
   schema: string,
   prefix: string = ""
 ): Promise<CreateTableReceipt> {
+  // We check the wallet and tableland chains match here again in
+  // case the user switched networks after creating a siwe token
+  await this.checkNetwork();
+
   const { chainId } = this.options;
   const query = `CREATE TABLE ${prefix}_${chainId} (${schema});`;
   // This "dryrun" is done to validate that the query statement is considered valid.

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -29,6 +29,10 @@ export async function write(
     return await tablelandCalls.write.call(this, query);
   }
 
+  // We check the wallet and tableland chains match here again in
+  // case the user switched networks after creating a siwe token
+  await this.checkNetwork();
+
   // ask the Validator if this query is valid, and get the tableId for use in SC call
   const { tableId } = await tablelandCalls.validateWriteQuery.call(this, query);
 

--- a/src/lib/siwe.ts
+++ b/src/lib/siwe.ts
@@ -4,8 +4,9 @@ import { getSigner } from "./util.js";
 
 export async function siwe(this: Connection): Promise<Token> {
   this.signer = this.signer ?? (await getSigner());
-  const chainId = this.options.chainId;
 
-  this.token = await userCreatesToken(this.signer, chainId);
+  await this.checkNetwork();
+
+  this.token = await userCreatesToken(this.signer, this.options.chainId);
   return this.token;
 }

--- a/src/lib/siwe.ts
+++ b/src/lib/siwe.ts
@@ -3,10 +3,10 @@ import { Token, userCreatesToken } from "./token.js";
 import { getSigner } from "./util.js";
 
 export async function siwe(this: Connection): Promise<Token> {
-  this.signer = this.signer ?? (await getSigner());
-
   await this.checkNetwork();
 
+  // Typescript wants this check here even though it's also done in `checkNetwork`
+  this.signer = this.signer ?? (await getSigner());
   this.token = await userCreatesToken(this.signer, this.options.chainId);
   return this.token;
 }

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -24,7 +24,7 @@ describe("connect function", function () {
 
   test("exposes signer with correct address", async function () {
     fetch.mockResponseOnce(FetchHashTableSuccess);
-    const connection = await connect({
+    const connection = connect({
       network: "testnet",
       host: "https://testnet.tableland.network",
     });
@@ -38,7 +38,7 @@ describe("connect function", function () {
   });
 
   test("exposes public methods and properties", async function () {
-    const connection = await connect({
+    const connection = connect({
       network: "testnet",
       host: "https://testnet.tableland.network",
     });
@@ -55,7 +55,7 @@ describe("connect function", function () {
 
   test("allows specifying connection network", async function () {
     const factorySpy = jest.spyOn(TablelandTables__factory, "connect");
-    const connection = await connect({
+    const connection = connect({
       network: "testnet",
       host: "https://testnetv2.tableland.network",
     });
@@ -72,7 +72,7 @@ describe("connect function", function () {
   });
 
   test("allows specifying connection token", async function () {
-    const connection1 = await connect({
+    const connection1 = connect({
       network: "testnet",
       host: "https://testnet.tableland.network",
     });
@@ -83,7 +83,7 @@ describe("connect function", function () {
     await new Promise((resolve) => setTimeout(() => resolve(null), 1001));
     await flushPromises();
 
-    const connection2 = await connect({
+    const connection2 = connect({
       network: "testnet",
       host: "https://testnet.tableland.network",
       token: connection1.token,
@@ -94,7 +94,7 @@ describe("connect function", function () {
 
   test("throws error if provider network is not supported", async function () {
     await expect(async function () {
-      return connect({
+      const connection = connect({
         network: "testnet",
         host: "https://testnetv2.tableland.network",
         signer: {
@@ -111,8 +111,10 @@ describe("connect function", function () {
           },
         } as unknown as Signer, // convince type checks into letting us mock the signer
       });
-    } as ConnectOptions).rejects.toThrow(
-      "proivder chain mismatch. Switch your wallet connection and reconnect"
+
+      await connection.siwe();
+    }).rejects.toThrow(
+      "provider chain and tableland network mismatch. Switch your wallet connection and reconnect"
     );
   });
 

--- a/test/createTable.test.ts
+++ b/test/createTable.test.ts
@@ -13,7 +13,7 @@ describe("create method", function () {
     // reset in case another test file hasn't cleaned up
     fetch.resetMocks();
     // const signer = ethers.providers.Web3Provider().getSigner();
-    connection = await connect({
+    connection = connect({
       network: "testnet",
       host: "https://testnetv2.tableland.network",
     });

--- a/test/list.test.ts
+++ b/test/list.test.ts
@@ -7,7 +7,7 @@ describe("list method", function () {
   beforeAll(async function () {
     // reset in case another test file hasn't cleaned up
     fetch.resetMocks();
-    connection = await connect({
+    connection = connect({
       network: "testnet",
       host: "https://testnet.tableland.network",
     });

--- a/test/receipt.test.ts
+++ b/test/receipt.test.ts
@@ -7,7 +7,7 @@ describe("has method", function () {
   beforeAll(async function () {
     // reset in case another test file hasn't cleaned up
     fetch.resetMocks();
-    connection = await connect({
+    connection = connect({
       network: "testnet",
       host: "https://testnet.tableland.network",
     });

--- a/test/runQuery.test.ts
+++ b/test/runQuery.test.ts
@@ -13,7 +13,7 @@ describe("read and write methods", function () {
   beforeAll(async function () {
     // reset in case another test file hasn't cleaned up
     fetch.resetMocks();
-    connection = await connect({
+    connection = connect({
       network: "testnet",
       host: "https://testnet.tableland.network",
     });
@@ -56,7 +56,7 @@ describe("read and write methods", function () {
     fetch.mockResponseOnce(FetchValidateWriteQuery);
     fetch.mockResponseOnce(FetchDirectRunSQLSuccess);
 
-    const connection = await connect({
+    const connection = connect({
       network: "testnet",
       host: "https://testnet.tableland.network",
       rpcRelay: false

--- a/test/structureHash.test.ts
+++ b/test/structureHash.test.ts
@@ -7,7 +7,7 @@ describe("has method", function () {
   beforeAll(async function () {
     // reset in case another test file hasn't cleaned up
     fetch.resetMocks();
-    connection = await connect({
+    connection = connect({
       network: "testnet",
       host: "https://testnet.tableland.network",
     });


### PR DESCRIPTION
Fixes #76

This is an interesting bug. When we fixed #22 we setup the possibility that the dev can specify a tableland network, but the wallet can be connected to a different tableland network chain.

One side affect here is that the connect method is now synchronous.  This won't break our API since you can `await` anything, but basically all of our examples in the docs will be out of date.