### PR TITLE
Update typedoc and typedoc-plugin-markdown to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,8 +42,8 @@
         "prettier": "^2.5.0",
         "ts-jest": "^27.1.3",
         "ts-node": "^9.1.1",
-        "typedoc": "^0.22.0",
-        "typedoc-plugin-markdown": "^3.11.12",
+        "typedoc": "^0.23.10",
+        "typedoc-plugin-markdown": "^3.13.4",
         "typescript": "^4.2.3"
       },
       "engines": {
@@ -10775,14 +10775,13 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
+      "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
       "dev": true,
       "dependencies": {
-        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^4.0.16",
+        "marked": "^4.0.18",
         "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       },
@@ -10790,10 +10789,10 @@
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 12.10.0"
+        "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
+        "typescript": "4.6.x || 4.7.x"
       }
     },
     "node_modules/typedoc-plugin-markdown": {
@@ -10815,25 +10814,6 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/typedoc/node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
@@ -19010,14 +18990,13 @@
       }
     },
     "typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
+      "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
       "dev": true,
       "requires": {
-        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^4.0.16",
+        "marked": "^4.0.18",
         "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       },
@@ -19029,19 +19008,6 @@
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^5.0.1",
-            "once": "^1.3.0"
           }
         },
         "minimatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "ts-node": "^9.1.1",
         "typedoc": "^0.23.10",
         "typedoc-plugin-markdown": "^3.13.4",
-        "typescript": "^4.2.3"
+        "typescript": "^4.7.4"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "ts-node": "^9.1.1",
     "typedoc": "^0.23.10",
     "typedoc-plugin-markdown": "^3.13.4",
-    "typescript": "^4.2.3"
+    "typescript": "^4.7.4"
   },
   "dependencies": {
     "siwe": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
     "prettier": "^2.5.0",
     "ts-jest": "^27.1.3",
     "ts-node": "^9.1.1",
-    "typedoc": "^0.22.0",
-    "typedoc-plugin-markdown": "^3.11.12",
+    "typedoc": "^0.23.10",
+    "typedoc-plugin-markdown": "^3.13.4",
     "typescript": "^4.2.3"
   },
   "dependencies": {


### PR DESCRIPTION
Part of https://github.com/tablelandnetwork/js-tableland/issues/73

I wasn't able to run `npm install` locally because of a version conflict related to these packages. This should fix that!

- [x] Tests pass
- [x] Appropriate changes to README are included in PR