### PR TITLE
Better typing, more consistent relay options

### DIFF
--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -70,6 +70,25 @@ export interface MethodOptions {
   timeout?: number;
 }
 
+export interface CreateOptions {
+  prefix?: string;
+  skipConfirm?: boolean;
+  timeout?: number;
+}
+
+export interface WriteOptions {
+  skipConfirm?: boolean;
+  rpcRelay?: boolean;
+}
+
+export interface SetControllerOptions {
+  rpcRelay?: boolean;
+}
+
+export interface HashOptions {
+  prefix?: string;
+}
+
 export interface ConfirmOptions {
   timeout?: number;
   rate?: number;
@@ -84,7 +103,7 @@ export interface Connection {
     chain?: ChainName;
     contract: string;
     chainId: number;
-    rpcRelay?: boolean;
+    rpcRelay: boolean;
   };
   list: () => Promise<TableMetadata[]>;
   create: (
@@ -99,21 +118,16 @@ export interface Connection {
     /**
      *  an optional options argument to specify conditions of create.
      **/
-    options?: MethodOptions
+    options?: CreateOptions
   ) => Promise<CreateTableReceipt>;
   read: (query: string) => Promise<ReadQueryResult>;
-  write: (
-    query: string,
-    options?: MethodOptions | undefined
-  ) => Promise<WriteQueryResult>;
-  hash: (
-    schema: string,
-    options?: MethodOptions
-  ) => Promise<StructureHashResult>;
+  write: (query: string, options?: WriteOptions) => Promise<WriteQueryResult>;
+  hash: (schema: string, options?: HashOptions) => Promise<StructureHashResult>;
   receipt: (txnHash: string) => Promise<ReceiptResult | undefined>;
   setController: (
     controller: string,
-    name: string
+    name: string,
+    options?: SetControllerOptions
   ) => Promise<WriteQueryResult>;
   getController: (tableName: string) => Promise<string>;
   lockController: (tableName: string) => Promise<WriteQueryResult>;

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -63,13 +63,6 @@ export interface StructureQueryResult {
   structure: string;
 }
 
-export interface MethodOptions {
-  prefix?: string;
-  skipConfirm?: boolean;
-  rpcRelay?: boolean;
-  timeout?: number;
-}
-
 export interface CreateOptions {
   prefix?: string;
   skipConfirm?: boolean;
@@ -93,6 +86,11 @@ export interface ConfirmOptions {
   timeout?: number;
   rate?: number;
 }
+
+export type PrefixOptions = HashOptions | CreateOptions;
+export type RelayOptions = WriteOptions | SetControllerOptions;
+export type SkipConfirmOptions = WriteOptions | CreateOptions;
+export type TimeoutOptions = ConfirmOptions | CreateOptions;
 
 export interface Connection {
   token?: Token;

--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "ethers";
-import { Connection, CreateTableReceipt, MethodOptions } from "./connection.js";
+import { Connection, CreateTableReceipt, CreateOptions } from "./connection.js";
 import * as tablelandCalls from "./tableland-calls.js";
 import * as ethCalls from "./eth-calls.js";
 import { getPrefix, getTimeout, shouldSkipConfirm } from "./util.js";
@@ -16,7 +16,7 @@ import { checkNetwork } from "./check-network.js";
 export async function create(
   this: Connection,
   schema: string,
-  options?: MethodOptions
+  options?: CreateOptions
 ): Promise<CreateTableReceipt> {
   // We check the wallet and tableland chains match here again in
   // case the user switched networks after creating a siwe token

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,9 +1,5 @@
 import { getPrefix } from "./util.js";
-import {
-  StructureHashResult,
-  Connection,
-  MethodOptions,
-} from "./connection.js";
+import { StructureHashResult, Connection, HashOptions } from "./connection.js";
 import * as tablelandCalls from "./tableland-calls.js";
 /**
  * Takes a Create Table SQL statement and returns the structure hash that would be generated
@@ -14,7 +10,7 @@ import * as tablelandCalls from "./tableland-calls.js";
 export async function hash(
   this: Connection,
   schema: string,
-  options?: MethodOptions
+  options?: HashOptions
 ): Promise<StructureHashResult> {
   const { chainId } = this.options;
   const prefix = getPrefix(options);

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -7,11 +7,11 @@ import {
   ReadQueryResult,
   WriteQueryResult,
   Connection,
-  MethodOptions,
+  WriteOptions,
 } from "./connection.js";
 import * as tablelandCalls from "./tableland-calls.js";
 import * as ethCalls from "./eth-calls.js";
-import { shouldSkipConfirm } from "./util.js";
+import { shouldSkipConfirm, shouldRelay } from "./util.js";
 import { checkNetwork } from "./check-network.js";
 
 export function resultsToObjects({ rows, columns }: ReadQueryResult) {
@@ -30,10 +30,11 @@ export async function read(
 export async function write(
   this: Connection,
   query: string,
-  options?: MethodOptions
+  options?: WriteOptions
 ): Promise<WriteQueryResult> {
   const skipConfirm = shouldSkipConfirm(options);
-  if (this.options.rpcRelay || options?.rpcRelay) {
+  const doRelay = shouldRelay(this, options);
+  if (doRelay) {
     const response = await tablelandCalls.write.call(this, query);
     if (!skipConfirm) await this.waitConfirm(response.hash);
 

--- a/src/lib/set-controller.ts
+++ b/src/lib/set-controller.ts
@@ -1,7 +1,12 @@
-import { Connection, WriteQueryResult } from "./connection.js";
+import {
+  Connection,
+  WriteQueryResult,
+  SetControllerOptions,
+} from "./connection.js";
 import * as tablelandCalls from "./tableland-calls.js";
 import * as ethCalls from "./eth-calls.js";
 import { checkNetwork } from "./check-network.js";
+import { shouldRelay } from "./util.js";
 
 /**
  * Set the Controller contract on a table
@@ -10,12 +15,14 @@ import { checkNetwork } from "./check-network.js";
 export async function setController(
   this: Connection,
   controller: string,
-  name: string
+  name: string,
+  options?: SetControllerOptions
 ): Promise<WriteQueryResult> {
   const tableId = name.trim().split("_").pop();
   if (typeof tableId !== "string") throw new Error("malformed tablename");
 
-  if (this.options.rpcRelay) {
+  const doRelay = shouldRelay(this, options);
+  if (doRelay) {
     // Note that since tablelandCalls all use the token, the networks are matched during token creation
     return await tablelandCalls.setController.call(this, tableId, controller);
   }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -4,8 +4,11 @@ import { proxies } from "@tableland/evm/proxies.js";
 import {
   Connection,
   ReceiptResult,
-  MethodOptions,
   ConfirmOptions,
+  PrefixOptions,
+  RelayOptions,
+  SkipConfirmOptions,
+  TimeoutOptions,
 } from "./connection.js";
 
 declare let globalThis: any;
@@ -159,30 +162,30 @@ export async function waitConfirm(
   return table;
 }
 
-export function getPrefix(options?: MethodOptions): string {
+export function getPrefix(options?: PrefixOptions): string {
   if (typeof options === "undefined") return "";
   return options.prefix || "";
 }
 
-export function shouldSkipConfirm(options?: MethodOptions): boolean {
+export function shouldSkipConfirm(options?: SkipConfirmOptions): boolean {
   if (typeof options === "undefined") return false;
   return !!options.skipConfirm;
 }
 
 export function shouldRelay(
   connection: Connection,
-  methodOptions?: MethodOptions
+  options?: RelayOptions
 ): boolean {
-  if (typeof methodOptions === "undefined") return connection.options.rpcRelay;
-  if (typeof methodOptions.rpcRelay === "boolean") {
-    return methodOptions.rpcRelay;
+  if (typeof options === "undefined") return connection.options.rpcRelay;
+  if (typeof options.rpcRelay === "boolean") {
+    return options.rpcRelay;
   }
 
   return connection.options.rpcRelay;
 }
 
 export const defaultTimeout = 120 * 1000; // 2 mintues
-export function getTimeout(options?: MethodOptions): number {
+export function getTimeout(options?: TimeoutOptions): number {
   if (typeof options === "undefined") return defaultTimeout;
   if (typeof options.timeout !== "number") return defaultTimeout;
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -169,6 +169,18 @@ export function shouldSkipConfirm(options?: MethodOptions): boolean {
   return !!options.skipConfirm;
 }
 
+export function shouldRelay(
+  connection: Connection,
+  methodOptions?: MethodOptions
+): boolean {
+  if (typeof methodOptions === "undefined") return connection.options.rpcRelay;
+  if (typeof methodOptions.rpcRelay === "boolean") {
+    return methodOptions.rpcRelay;
+  }
+
+  return connection.options.rpcRelay;
+}
+
 export const defaultTimeout = 120 * 1000; // 2 mintues
 export function getTimeout(options?: MethodOptions): number {
   if (typeof options === "undefined") return defaultTimeout;


### PR DESCRIPTION
This is a fix to an issue from Discord: https://discord.com/channels/592843512312102924/1006245128589037619
See below if you don't have Discord access.

TL;DR; The rpcRelay option is potentially specified in the sdk connect method, but devs have been wanting to specify with a per method call option.  We had started to implement this, but never finished.  
This also makes the types more specific.

**OP from Discord:**
> issue re: rpcRelay and potential missing impl...or we just need better docs on MethodOptions since its rpcRelay is an optional param that is not used at all in certain methods. OR -- we havent implemented the method-level logic to process MethodOptions and its rpcRelay yet
> https://discord.com/channels/592843512312102924/968582612945870878/1006196867765391391
> 
> after digging into this a bit, it looks like write can take a MethodOptions param as part of the Connection object's definition. but, if you look at the write method's impl itself, there is not a param to pass the MethodOptions. thus, when a user tries to pass rpcRelay: false in a write method call, the default Connection's rpcRelay is used (which is likely true unless otherwise specified). the Connection's rpcRelay logic is also linked below, for reference, as there might be some other aspects to consider, as noted in the original Discord comment.
> 
> - Connection showing the options can be passed to write: https://github.com/tablelandnetwork/js-tableland/blob/ba13ae3355971403801d758a03963e94f2a6c189/src/lib/connection.ts#L107
> - write, which doesnt take MethodOptions at all: https://github.com/tablelandnetwork/js-tableland/blob/ba13ae3355971403801d758a03963e94f2a6c189/src/lib/tableland-calls.ts#L143
> - create, which doesn't use rpcRelay from the options. i suppose this makes sense from a logic perspective b/c we dont give the option to relay creates at the validator...but we do offer validator relays for writes, which i think is a conflicting DX across these two calls. note that hash has a similar situation: https://github.com/tablelandnetwork/js-tableland/blob/ba13ae3355971403801d758a03963e94f2a6c189/src/lib/create.ts#L19
> - rpcRelay logic within Connection: https://github.com/tablelandnetwork/js-tableland/blob/ba13ae3355971403801d758a03963e94f2a6c189/src/lib/connector.ts#L74
> 
> also, write only has logic to use relayWriteQuery under the hood and doesnt use runSql (from eth-calls.ts), so it looks like we'd have to add some logic to make a direct SC call for write as well? 
> 
> there's a bunch going on that i dont have the best insight into from an engg perspective, so i just wanna make sure my logic is correct before i open a GH issue or formalize this as a friction log. maybe its all in an obj somewhere that i couldnt find
> 
