### PR TITLE
rename registerTable to createTable

### DIFF
--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -34,7 +34,7 @@ export async function create(
   // then fail to create the table on the Tableland network
   await tablelandCalls.hash.call(this, query);
 
-  const txn = await ethCalls.registerTable.call(this, query);
+  const txn = await ethCalls.createTable.call(this, query);
 
   const [, event] = txn.events ?? [];
   const txnHash = txn.transactionHash;

--- a/src/lib/eth-calls.ts
+++ b/src/lib/eth-calls.ts
@@ -3,7 +3,7 @@ import { Overrides, ContractReceipt, Signer } from "ethers";
 import { Connection } from "./connection.js";
 import { getSigner } from "./util.js";
 
-async function registerTable(
+async function createTable(
   this: Connection,
   query: string
 ): Promise<ContractReceipt> {
@@ -95,4 +95,4 @@ async function getOverrides(signer: Signer): Promise<Overrides> {
   return opts;
 }
 
-export { registerTable, runSql, setController, getController, lockController };
+export { createTable, runSql, setController, getController, lockController };


### PR DESCRIPTION
fix #97 Rename the registerTable to createTable.
Since registerTable was internal this is a pretty simple change