### PR TITLE
Update connect to accept an optional siweUri argument

### DIFF
--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -102,6 +102,7 @@ export interface Connection {
     contract: string;
     chainId: number;
     rpcRelay: boolean;
+    siweUri: string;
   };
   list: () => Promise<TableMetadata[]>;
   create: (

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -40,6 +40,8 @@ export interface ConnectOptions {
   contract?: string;
   // Boolean that indicates if tableland writes should be relayed via Validator
   rpcRelay?: boolean;
+  // SIWE URI. Defaults to document.location.origin when used in a browser environment and to https://tableland.xyz if document.location is not available.
+  siweUri?: string;
 }
 
 /**
@@ -75,6 +77,10 @@ export function connect(options: ConnectOptions): Connection {
     typeof options.rpcRelay === "boolean" ? options.rpcRelay : info.rpcRelay;
   // If a token was provided, we cache it
   const token = options.token;
+  const siweUri =
+    options.siweUri ??
+    globalThis.document?.location.origin ??
+    "https://tableland.xyz";
   const connectionObject: Connection = {
     token,
     signer,
@@ -85,6 +91,7 @@ export function connect(options: ConnectOptions): Connection {
       chain,
       chainId,
       contract,
+      siweUri,
     },
     get list() {
       return list;

--- a/src/lib/siwe.ts
+++ b/src/lib/siwe.ts
@@ -6,6 +6,10 @@ export async function siwe(this: Connection): Promise<Token> {
   // calling this ensures that we have a signer
   await checkNetwork.call(this);
 
-  this.token = await userCreatesToken(this.signer!, this.options.chainId);
+  this.token = await userCreatesToken(
+    this.signer!,
+    this.options.chainId,
+    this.options.siweUri
+  );
   return this.token;
 }

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -50,7 +50,8 @@ async function createToken(
 
 export async function userCreatesToken(
   signer: Signer,
-  chainId: number
+  chainId: number,
+  uri: string
 ): Promise<Token> {
   const now = Date.now();
   const exp = new Date(now + 10 * 60 * 60 * 1000).toISOString(); // Default to ~10 hours
@@ -58,7 +59,7 @@ export async function userCreatesToken(
   return await createToken(signer, {
     chainId,
     expirationTime: exp,
-    uri: globalThis.document?.location.origin,
+    uri,
     version: "1",
     statement: "Official Tableland SDK",
   });

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -94,6 +94,24 @@ describe("connect function", function () {
     expect(connection1.token?.token === connection2.token?.token).toBe(true);
   });
 
+  test("allows specifying SIWE URI", async function () {
+    const siweUri = "https://test.xyz";
+    const connection1 = connect({
+      network: "testnet",
+      host: "https://testnet.tableland.network",
+      siweUri,
+    });
+
+    expect(connection1.options.siweUri).toBe(siweUri);
+
+    const connection2 = connect({
+      network: "testnet",
+      host: "https://testnet.tableland.network",
+    });
+
+    expect(connection2.options.siweUri).not.toBe(siweUri);
+  });
+
   test("throws error if provider network is not supported", async function () {
     await expect(async function () {
       const connection = connect({


### PR DESCRIPTION
URI is required in a `SiweMessage` according to the [siwe spec](https://eips.ethereum.org/EIPS/eip-4361) so we need a way to pass in a URI when creating messages in non-browser environments, like the cli. This is also required to upgrade siwe to v2 since `SiweMessage` validates that the uri field is a valid URI here https://github.com/spruceid/siwe/blob/07103f2b72cfe0363d5c605cd6ebf9791d82cad5/packages/siwe/lib/client.ts#L382-L388

Do you think using a connection option is the right way to do it? If yes, do you prefer to use a default fallback value (like I did with tableland.xyz) or do you think `connect` should throw an error if a siwe URI isn't provided? I was debating between the two options but went with not requiring it since you can use the read only function sin the sdk without needing to siwe