### PR TITLE
Add Arbitrum mainnet fix #167

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+test/integration/build/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+test/integration/build/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",
-        "@tableland/evm": "^2.0.4",
+        "@tableland/evm": "^3.0.0",
         "camelcase": "^6.3.0",
         "ethers": "^5.6.9",
         "siwe": "^2.0.5"
@@ -3378,9 +3378,9 @@
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "node_modules/@tableland/evm": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-2.0.4.tgz",
-      "integrity": "sha512-LCKBk4XViHQSt+iDgS8ZBfGxrQVnqWbKZcLy7yolznu0UvxIO7wta8a0vMfdaElB9sLeN0e8XLzWeD2fHt9lhA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-3.0.0.tgz",
+      "integrity": "sha512-KbfnXaj3XpTXui//Yg5tOUxjBcrevX+nQhfeBzNK9n/Hi8nNsMAOkRfxR2kojoGWoAhTRhqFXmf7ml5rjRADqA==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -13245,9 +13245,9 @@
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "@tableland/evm": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-2.0.4.tgz",
-      "integrity": "sha512-LCKBk4XViHQSt+iDgS8ZBfGxrQVnqWbKZcLy7yolznu0UvxIO7wta8a0vMfdaElB9sLeN0e8XLzWeD2fHt9lhA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-3.0.0.tgz",
+      "integrity": "sha512-KbfnXaj3XpTXui//Yg5tOUxjBcrevX+nQhfeBzNK9n/Hi8nNsMAOkRfxR2kojoGWoAhTRhqFXmf7ml5rjRADqA=="
     },
     "@tableland/local": {
       "version": "0.0.0-pre11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableland/sdk",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/sdk",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/sdk",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A TypeScript/JavaScript library for creating and querying Tables on the Tableland network.",
   "repository": "https://github.com/tablelandnetwork/js-tableland",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@stablelib/base64": "^1.0.1",
-    "@tableland/evm": "^2.0.4",
+    "@tableland/evm": "^3.0.0",
     "camelcase": "^6.3.0",
     "ethers": "^5.6.9",
     "siwe": "^2.0.5"

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -101,11 +101,11 @@ export const SUPPORTED_CHAINS: Record<ChainName, SupportedChain> = {
     host: "https://testnet.tableland.network",
     rpcRelay: true,
   },
-  "arbitrum": {
+  arbitrum: {
     name: "arbitrum",
     phrase: "Arbitrum",
     chainId: 42161,
-    contract: evm.proxies["arbitrum"],
+    contract: evm.proxies.arbitrum,
     host: "https://testnet.tableland.network",
     rpcRelay: false,
   },

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -40,6 +40,7 @@ export type ChainName =
   | "ethereum"
   | "optimism"
   | "polygon"
+  | "arbitrum"
   | "ethereum-goerli"
   | "optimism-goerli"
   | "arbitrum-goerli"
@@ -99,6 +100,14 @@ export const SUPPORTED_CHAINS: Record<ChainName, SupportedChain> = {
     contract: evm.proxies["arbitrum-goerli"],
     host: "https://testnet.tableland.network",
     rpcRelay: true,
+  },
+  "arbitrum": {
+    name: "arbitrum",
+    phrase: "Arbitrum",
+    chainId: 42161,
+    contract: evm.proxies["arbitrum"],
+    host: "https://testnet.tableland.network",
+    rpcRelay: false,
   },
   "polygon-mumbai": {
     name: "maticmum",

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,7 +1,7 @@
 import { Signer, ethers } from "ethers";
 import BufferPolyfil from "buffer";
 import camelCase from "camelcase";
-import * as evm from "@tableland/evm/proxies.js";
+import * as evm from "@tableland/evm/network.js";
 import {
   Connection,
   ReceiptResult,


### PR DESCRIPTION
Adds Arbitrum mainnet to list of tableland networks.
Notes:
 - Looks like we updated our eslint dependency and we have a lot of linting fixes all of a sudden.  I'll investigate later today
 - Need to ensure that evm-tableland proxies -> network file name is published and incorporated correctly with this pull request and publish.
cc: @carsonfarmer If you have time for a sync voice on getting this and evm published let me know.