### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm i @tableland/sdk
 
 :warning: Please ensure you are using Node 18 (or newer).
 
-If you are using versions prior to v18, you will need to provide global access to `node-fetch`. Instructions on how to implement this can be found [here](https://github.com/node-fetch/node-fetch#providing-global-access).
+If you are using versions prior to v18, you will need to provide global access to `fetch`. Instructions on how to implement this can be found in the `node-fetch` documentation [here](https://github.com/node-fetch/node-fetch#providing-global-access). For Node 16, in particular, you can try using the [`--experimental-fetch`](https://nodejs.org/fa/blog/release/v16.15.0/#add-fetch-api) flag, which installs the `fetch`, `Request`, `Response`, `Headers`, and `FormData` globals.
 
 > Note: Not seeing the build type you need for your project or idea? Let us know, we're happy to work with you to improve the SDK usability!
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Installation is easy using npm or yarn. An ES bundle is also available for those
 npm i @tableland/sdk
 ```
 
+:warning: Please ensure you are using Node 18 (or newer).
+
+If you are using versions prior to v18, you will need to provide global access to `node-fetch`. Instructions on how to implement this can be found [here](https://github.com/node-fetch/node-fetch#providing-global-access).
+
 > Note: Not seeing the build type you need for your project or idea? Let us know, we're happy to work with you to improve the SDK usability!
 
 # Usage


### PR DESCRIPTION
## Summary

Devs often run into `node-fetch` issues and don't know what to do. The docs site tries to call this out early (not always effective...), but the README does not make mention of the requirement for Node 18+.

## Details

Adds context on Node 18 requirement and how to import `node-fetch` with <v18.
