### PR TITLE
Increase test setup timeout duration

### DIFF
--- a/test/integration/setupTest.ts
+++ b/test/integration/setupTest.ts
@@ -13,7 +13,7 @@ export const setup = function (t: Test) {
   }
 
   // increase the timeout since this might take a while
-  t.timeoutAfter(15 * 1000);
+  t.timeoutAfter(20 * 1000);
   // if the promise exists return it so the caller can await it
   if (initializing) return initializing;
 


### PR DESCRIPTION
Looks like the 15 second test setup timeout in #278 was marginally long enough.  The test run for the PR passed but the test run for the merge failed.  This increases the timeout from 15 seconds to 20 seconds which should be plenty long.