### PR TITLE
chore: test against latest validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@babel/preset-env": "^7.19.3",
         "@babel/preset-typescript": "^7.16.7",
         "@babel/register": "^7.18.9",
-        "@tableland/local": "^0.0.4",
+        "@tableland/local": "^0.0.5-pre.2",
         "@types/chai": "^4.2.22",
         "@types/jest": "^29.0.3",
         "@types/mocha": "^10.0.0",
@@ -3747,9 +3747,9 @@
       }
     },
     "node_modules/@tableland/local": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-0.0.4.tgz",
-      "integrity": "sha512-NM+Y2hodlyeCxhyMfDIkavsAr1Q8KiLWPh7ICO1vMuMs0ti5HfNxCafa5v9jrM1Pzh2MmRwHNGKPinv8ClMSPg==",
+      "version": "0.0.5-pre.2",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-0.0.5-pre.2.tgz",
+      "integrity": "sha512-UHNcXz5mebFQU3bsD0+ivKm7KzQgZ7/wAZyjxKdAj6k15BcgNiH9zT20GQjAJoP/yZHLMLVIGoGP7hlgRfVaGA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -13566,9 +13566,9 @@
       "integrity": "sha512-Ci8QJubb6Z4ipPANALqAPQ9byh0tsRWZREej8QXGqLfHRqCAJfnMRTy2f47Oqq7IQ6Ajcy5holeUr9EtSmXNXA=="
     },
     "@tableland/local": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-0.0.4.tgz",
-      "integrity": "sha512-NM+Y2hodlyeCxhyMfDIkavsAr1Q8KiLWPh7ICO1vMuMs0ti5HfNxCafa5v9jrM1Pzh2MmRwHNGKPinv8ClMSPg==",
+      "version": "0.0.5-pre.2",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-0.0.5-pre.2.tgz",
+      "integrity": "sha512-UHNcXz5mebFQU3bsD0+ivKm7KzQgZ7/wAZyjxKdAj6k15BcgNiH9zT20GQjAJoP/yZHLMLVIGoGP7hlgRfVaGA==",
       "dev": true,
       "requires": {
         "@tableland/sdk": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@babel/preset-env": "^7.19.3",
     "@babel/preset-typescript": "^7.16.7",
     "@babel/register": "^7.18.9",
-    "@tableland/local": "^0.0.4",
+    "@tableland/local": "^0.0.5-pre.2",
     "@types/chai": "^4.2.22",
     "@types/jest": "^29.0.3",
     "@types/mocha": "^10.0.0",


### PR DESCRIPTION
This is a "legacy snapshot" of our current SDK. It is being tested against the latest validator APIs, and all tests are passing. We can keep this branch alive for a period of time after the switch that corresponds with the period of time we keep the existing JSON RPC APIs alive on the validator. This will provide some time for folks to make the SDK switch. We can continue to publish patch updates on this branch to the 3.x version, while core fixes and new features/updates happen on the 4.x version (which will become the new main branch).

cc @joewagner (who's good idea this was)

I'm leaving this in draft mode because we don't actually want to merge this into main.