### PR TITLE
Trim whitespace from create statements

### DIFF
--- a/src/registry/create.ts
+++ b/src/registry/create.ts
@@ -25,7 +25,6 @@ export async function prepareCreateTable({
     `${first}_${chainId}`,
     true
   );
-  statement = statement.trim();
   const stmt = statement.replace(
     firstSearch,
     function (_, create: string, name: string, schema: string) {

--- a/src/registry/create.ts
+++ b/src/registry/create.ts
@@ -25,9 +25,8 @@ export async function prepareCreateTable({
     `${first}_${chainId}`,
     true
   );
-  const stmt = statement
-    .trim()
-    .replace(
+  statement = statement.trim();
+  const stmt = statement.replace(
     firstSearch,
     function (_, create: string, name: string, schema: string) {
       const newName = name.replace(secondSearch, function (sub, ...args) {

--- a/src/registry/create.ts
+++ b/src/registry/create.ts
@@ -25,7 +25,7 @@ export async function prepareCreateTable({
     `${first}_${chainId}`,
     true
   );
-  const stmt = statement.replace(
+  const stmt = statement.trim().replace(
     firstSearch,
     function (_, create: string, name: string, schema: string) {
       const newName = name.replace(secondSearch, function (sub, ...args) {

--- a/src/registry/create.ts
+++ b/src/registry/create.ts
@@ -25,7 +25,9 @@ export async function prepareCreateTable({
     `${first}_${chainId}`,
     true
   );
-  const stmt = statement.trim().replace(
+  const stmt = statement
+    .trim()
+    .replace(
     firstSearch,
     function (_, create: string, name: string, schema: string) {
       const newName = name.replace(secondSearch, function (sub, ...args) {

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -40,7 +40,7 @@ export class Statement<S = unknown> {
     parameters?: Parameters
   ) {
     this.config = config;
-    this.sql = sql;
+    this.sql = sql.trim();
     this.parameters = parameters;
   }
 


### PR DESCRIPTION
Fixes bug where whitespace at the beginning of a create statement prevents the SDK from adding the chainID to the create statement before sending it to the registry. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
