### PR TITLE
help get chainId in multiple environments

### DIFF
--- a/src/helpers/chains.ts
+++ b/src/helpers/chains.ts
@@ -57,10 +57,19 @@ const supportedChainsById = Object.fromEntries(
  * @returns An object containing the default chainId, contractAddress, chainName, and baseUrl for the given chain.
  */
 export function getChainInfo(chainNameOrId: ChainName | number): ChainInfo {
-  if (typeof chainNameOrId === "number") {
-    return supportedChainsById[chainNameOrId];
+  const chainInfo =
+    typeof chainNameOrId === "number"
+      ? supportedChainsById[chainNameOrId]
+      : supportedChains[chainNameOrId];
+
+  // Something about the way we are using `Object.fromEntries` to generate these
+  // maps makes eslint think that this value is always true, hence the disable
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+  if (!chainInfo) {
+    throw new Error(`cannot use unsupported chain: ${chainNameOrId}`);
   }
-  return supportedChains[chainNameOrId];
+
+  return chainInfo;
 }
 
 export function isTestnet(chainNameOrId: ChainName | number): boolean {

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -43,3 +43,16 @@ export async function extractSigner(
   }
   return conn.signer;
 }
+
+export async function extractChainId(conn: Config): Promise<number> {
+  const signer = await extractSigner(conn);
+  const chainId = await signer.getChainId();
+
+  if (chainId === 0 || isNaN(chainId) || chainId == null) {
+    throw new Error(
+      "cannot find chainId: is your signer connected to a network?"
+    );
+  }
+
+  return chainId;
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -21,6 +21,7 @@ export {
   type Config,
   type AutoWaitConfig,
   extractBaseUrl,
+  extractChainId,
   extractSigner,
 } from "./config.js";
 export {

--- a/src/registry/utils.ts
+++ b/src/registry/utils.ts
@@ -7,6 +7,7 @@ import {
   type Config,
   type ReadConfig,
   extractBaseUrl,
+  extractChainId,
 } from "../helpers/config.js";
 import {
   type ContractTransaction,
@@ -79,12 +80,16 @@ export async function extractReadonly(
 }
 
 export async function wrapTransaction(
-  conn: ReadConfig,
+  conn: Config,
   prefix: string,
   tx: ContractTransaction
 ): Promise<WaitableTransactionReceipt> {
   const params = await getContractReceipt(tx);
-  const name = `${prefix}_${params.chainId}_${params.tableId}`;
+  const chainId =
+    params.chainId === 0 || params.chainId == null
+      ? await extractChainId(conn)
+      : params.chainId;
+  const name = `${prefix}_${chainId}_${params.tableId}`;
   const wait = async (
     opts: SignalAndInterval = {}
   ): Promise<TransactionReceipt & Named> => {

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -40,7 +40,7 @@ export class Statement<S = unknown> {
     parameters?: Parameters
   ) {
     this.config = config;
-    this.sql = sql;
+    this.sql = sql.trim();
     this.parameters = parameters;
   }
 


### PR DESCRIPTION
fix #366 

When connecting with Metamask the chainId is not available in the same way as when connecting in a node.js environment.
This contains some alternative checks for chainId, and includes some error messaging to inform devs of connection problems.