### PR TITLE
Remove use of `Function` as a type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint": "^8.31.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-config-standard": "^17.0.0",
-        "eslint-config-standard-with-typescript": "^27.0.1",
+        "eslint-config-standard-with-typescript": "^31.0.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-n": "^15.6.0",
         "eslint-plugin-promise": "^6.1.1",
@@ -2188,9 +2188,9 @@
       }
     },
     "node_modules/eslint-config-standard-with-typescript": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-27.0.1.tgz",
-      "integrity": "sha512-jJVyJldqqiCu3uSA/FP0x9jCDMG+Bbl73twTSnp0aysumJrz4iaVqLl+tGgmPrv0R829GVs117Nmn47M1DDDXA==",
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-31.0.0.tgz",
+      "integrity": "sha512-FLTrcJR62gPPPFwwverxwDTcQDb4HOCfDqmELZgNMSbh1M/Ui36X47a9ZANeo3iuPhMOfvrfuShChW9chdasnA==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/parser": "^5.0.0",
@@ -6432,9 +6432,9 @@
       "requires": {}
     },
     "eslint-config-standard-with-typescript": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-27.0.1.tgz",
-      "integrity": "sha512-jJVyJldqqiCu3uSA/FP0x9jCDMG+Bbl73twTSnp0aysumJrz4iaVqLl+tGgmPrv0R829GVs117Nmn47M1DDDXA==",
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-31.0.0.tgz",
+      "integrity": "sha512-FLTrcJR62gPPPFwwverxwDTcQDb4HOCfDqmELZgNMSbh1M/Ui36X47a9ZANeo3iuPhMOfvrfuShChW9chdasnA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/parser": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "eslint": "^8.31.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-config-standard": "^17.0.0",
-    "eslint-config-standard-with-typescript": "^27.0.1",
+    "eslint-config-standard-with-typescript": "^31.0.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-n": "^15.6.0",
     "eslint-plugin-promise": "^6.1.1",

--- a/src/validator/receipt.ts
+++ b/src/validator/receipt.ts
@@ -81,5 +81,10 @@ export async function pollTransactionReceipt(
     }
   };
   const receipt = await getAsyncPoller(fn, interval, signal);
+
+  if (typeof receipt === "undefined") {
+    throw new Error("could not get transaction receipt");
+  }
+
   return receipt;
 }

--- a/test/await.test.ts
+++ b/test/await.test.ts
@@ -14,7 +14,7 @@ describe("await", function () {
     async function testPolling({
       signal,
       interval,
-    }: SignalAndInterval = {}): Promise<boolean> {
+    }: SignalAndInterval = {}): Promise<boolean | undefined> {
       let first = true;
       const fn: AsyncFunction<boolean> = async () => {
         callCount += 1;
@@ -38,7 +38,7 @@ describe("await", function () {
     async function testPolling({
       signal,
       interval,
-    }: SignalAndInterval = {}): Promise<boolean> {
+    }: SignalAndInterval = {}): Promise<boolean | undefined> {
       const fn: AsyncFunction<boolean> = async () => {
         return { done: false };
       };


### PR DESCRIPTION
Looks like maybe there was a simultaneous PR that fixes this, we might be able to ignore this.