### PR TITLE
Pass more meaningful error messages.

### DIFF
--- a/src/helpers/chains.ts
+++ b/src/helpers/chains.ts
@@ -112,13 +112,16 @@ export function overrideDefaults(
   chainNameOrId: ChainName | number,
   values: Record<keyof ChainInfo, number | string>
 ): void {
+  if (values == null || typeof values !== "object") {
+    throw new Error("override values must be an Object");
+  }
   for (const [key, value] of Object.entries(values)) {
     if (typeof chainNameOrId === "number") {
-      const found = supportedChainsById[chainNameOrId];
+      const found = getChainInfo(chainNameOrId);
       found[key] = value;
       supportedChains[found.chainName][key as keyof ChainInfo] = value;
     } else {
-      const found = supportedChains[chainNameOrId];
+      const found = getChainInfo(chainNameOrId);
       found[key] = value;
       supportedChainsById[found.chainId][key as keyof ChainInfo] = value;
     }

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -16,7 +16,7 @@ export interface AutoWaitConfig {
 export type Config = Partial<ReadConfig & SignerConfig>;
 
 export async function extractBaseUrl(
-  conn: Config,
+  conn: Config = {},
   chainNameOrId?: ChainName | number
 ): Promise<string> {
   if (conn.baseUrl == null) {
@@ -35,7 +35,7 @@ export async function extractBaseUrl(
 }
 
 export async function extractSigner(
-  conn: Config,
+  conn: Config = {},
   external?: ExternalProvider
 ): Promise<Signer> {
   if (conn.signer == null) {
@@ -44,7 +44,7 @@ export async function extractSigner(
   return conn.signer;
 }
 
-export async function extractChainId(conn: Config): Promise<number> {
+export async function extractChainId(conn: Config = {}): Promise<number> {
   const signer = await extractSigner(conn);
   const chainId = await signer.getChainId();
 

--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -10,6 +10,9 @@ import { isTestnet } from "./chains.js";
 export type { NormalizedStatement, StatementType };
 
 export async function normalize(sql: string): Promise<NormalizedStatement> {
+  if (typeof sql !== "string") {
+    throw new Error("SQL statement must be a String");
+  }
   /* c8 ignore next 3 */
   if (__wasm == null) {
     await init();
@@ -21,6 +24,9 @@ export async function validateTableName(
   tableName: string,
   isCreate = false
 ): Promise<ValidatedTable> {
+  if (typeof tableName !== "string") {
+    throw new Error("table name must be a String");
+  }
   /* c8 ignore next 3 */
   if (__wasm == null) {
     await init();

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -41,7 +41,7 @@ export class Registry {
    * Signer. If passing the config from a pre-existing Database instance, it
    * must have a non-null signer key defined.
    */
-  constructor(config: Partial<SignerConfig>) {
+  constructor(config: Partial<SignerConfig> = {}) {
     /* c8 ignore next 3 */
     if (config.signer == null) {
       throw new Error("missing signer information");

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -51,6 +51,10 @@ export class Statement<S = unknown> {
     sql: string,
     parameters?: Parameters
   ) {
+    if (typeof sql !== "string") {
+      throw new Error("SQL statement must be a String");
+    }
+
     this.config = config;
     this.sql = sql.trim();
     this.parameters = parameters;

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -42,7 +42,7 @@ export class Validator {
    * string. If passing the config from a pre-existing Database instance, it
    * must have a non-null baseUrl key defined.
    */
-  constructor(config: Partial<ReadConfig>) {
+  constructor(config: Partial<ReadConfig> = {}) {
     /* c8 ignore next 3 */
     if (config.baseUrl == null) {
       throw new Error("missing baseUrl information");

--- a/test/chains.test.ts
+++ b/test/chains.test.ts
@@ -1,4 +1,4 @@
-import { strictEqual } from "assert";
+import { strictEqual, throws } from "assert";
 import { describe, test } from "mocha";
 import {
   getBaseUrl,
@@ -8,6 +8,7 @@ import {
   isTestnet,
   type ChainName,
   supportedChains,
+  overrideDefaults,
 } from "../src/helpers/chains.js";
 
 describe("chains", function () {
@@ -91,6 +92,19 @@ describe("chains", function () {
       const maticmum = getChainInfo("maticmum");
       strictEqual(maticmum.baseUrl, testnetsUrl);
       strictEqual(maticmum.chainId, 80001);
+    });
+  });
+
+  describe("overrideDefaults()", function () {
+    test("when called incorrectly", async function () {
+      throws(
+        // @ts-expect-error need to tell ts to ignore this since we are testing a failure when used without ts
+        () => overrideDefaults("homestead"), // didn't pass in overrides
+        (err: any) => {
+          strictEqual(err.message, "override values must be an Object");
+          return true;
+        }
+      );
     });
   });
 });

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,0 +1,31 @@
+import { strictEqual, rejects } from "assert";
+import { describe, test } from "mocha";
+import { normalize, validateTableName } from "../src/helpers/parser.js";
+
+describe("parser", function () {
+  describe("normalize()", function () {
+    test("when called incorrectly", async function () {
+      await rejects(
+        // @ts-expect-error need to tell ts to ignore this since we are testing a failure when used without ts
+        normalize(123),
+        (err: any) => {
+          strictEqual(err.message, "SQL statement must be a String");
+          return true;
+        }
+      );
+    });
+  });
+
+  describe("validateTableName()", function () {
+    test("when called incorrectly", async function () {
+      await rejects(
+        // @ts-expect-error need to tell ts to ignore this since we are testing a failure when used without ts
+        validateTableName(123),
+        (err: any) => {
+          strictEqual(err.message, "table name must be a String");
+          return true;
+        }
+      );
+    });
+  });
+});

--- a/test/statement.test.ts
+++ b/test/statement.test.ts
@@ -36,6 +36,18 @@ describe("statement", function () {
     deepStrictEqual(stmt, new Statement(db.config, sql));
   });
 
+  test("when initialized incorrectly", async function () {
+    const sqlString = 12;
+    throws(
+      // @ts-expect-error need to tell ts to ignore this since we are testing a failure when used without ts
+      () => new Statement(db.config, sqlString),
+      (err: any) => {
+        strictEqual(err.message, "SQL statement must be a String");
+        return true;
+      }
+    );
+  });
+
   describe(".run()", function () {
     let tableName: string;
     this.beforeAll(async function () {


### PR DESCRIPTION
There's a few places in the SDK where an incorrect call to a function, or constructor, results in a `cannot read properties of undefined` or `xyz is not a function` error.  This PR will pass a more human friendly message so devs can debug more easily.