### PR TITLE
Add deprecated to Database.readOnly docstring

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -35,6 +35,7 @@ export class Database<D = unknown> {
 
   /**
    * Create a Database that uses the default baseUrl for a given chain.
+   * @deprecated since 4.0.1
    * @param chainNameOrId The name or id of the chain to target.
    * @returns A Database without a signer configured.
    */

--- a/src/database.ts
+++ b/src/database.ts
@@ -35,11 +35,14 @@ export class Database<D = unknown> {
 
   /**
    * Create a Database that uses the default baseUrl for a given chain.
-   * @deprecated since 4.0.1
+   * @deprecated since 4.0.1, will be deleted in 5.0.0
    * @param chainNameOrId The name or id of the chain to target.
    * @returns A Database without a signer configured.
    */
   static readOnly(chainNameOrId: ChainName | number): Database {
+    console.warn(
+      "`Database.readOnly()` is a depricated method, use `new Database()`"
+    );
     const baseUrl = getBaseUrl(chainNameOrId);
     return new Database({ baseUrl });
   }


### PR DESCRIPTION
This deprecates the Database.readOnly() static by adding to the docstring and logging a warning to the console.

Related to #375 