### PR TITLE
[JST-11] SDK uses ethers v6 internally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@tableland/evm": "^4.2.2",
         "@tableland/sqlparser": "^1.0.6-pre.5",
-        "ethers": "^5.7.2"
+        "ethers": "^6.3.0"
       },
       "devDependencies": {
         "@databases/escape-identifier": "^1.0.3",
@@ -41,6 +41,11 @@
         "typedoc": "^0.24.6",
         "typescript": "^4.9.4"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
+      "integrity": "sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ=="
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -141,6 +146,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
       "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -167,6 +173,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
       "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -191,6 +198,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
       "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -213,6 +221,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
       "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -235,6 +244,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
       "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -253,6 +263,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
       "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -272,6 +283,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
       "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -292,6 +304,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
       "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -310,6 +323,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
       "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -328,6 +342,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
       "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -372,10 +387,59 @@
         "scrypt-js": "3.0.1"
       }
     },
+    "node_modules/@ethersproject/experimental/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
+      }
+    },
     "node_modules/@ethersproject/hash": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
       "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -402,6 +466,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
       "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -431,6 +496,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
       "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -457,10 +523,17 @@
         "scrypt-js": "3.0.1"
       }
     },
+    "node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "dev": true
+    },
     "node_modules/@ethersproject/keccak256": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
       "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -480,6 +553,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
       "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -495,6 +569,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
       "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -513,6 +588,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
       "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -532,6 +608,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
       "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -550,6 +627,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
       "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -583,10 +661,32 @@
         "ws": "7.4.6"
       }
     },
+    "node_modules/@ethersproject/providers/node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ethersproject/random": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
       "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -606,6 +706,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
       "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -625,6 +726,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
       "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -645,6 +747,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
       "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -668,6 +771,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
       "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -691,6 +795,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
       "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -711,6 +816,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
       "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -737,6 +843,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
       "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -757,6 +864,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
       "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -789,6 +897,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
       "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -811,6 +920,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
       "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -896,6 +1006,28 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -980,6 +1112,54 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tableland/local/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
+      }
+    },
     "node_modules/@tableland/sdk": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.2.1.tgz",
@@ -996,6 +1176,54 @@
       "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.5.tgz",
       "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg==",
       "dev": true
+    },
+    "node_modules/@tableland/sdk/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
+      }
     },
     "node_modules/@tableland/sqlparser": {
       "version": "1.0.6-pre.5",
@@ -1367,9 +1595,9 @@
       }
     },
     "node_modules/aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.3.tgz",
+      "integrity": "sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -1548,7 +1776,8 @@
     "node_modules/bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -1562,7 +1791,8 @@
     "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1589,7 +1819,8 @@
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -1920,6 +2151,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -1933,7 +2165,8 @@
     "node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2520,13 +2753,13 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.3.0.tgz",
+      "integrity": "sha512-CKFYvTne1YT4S1glTiu7TgGsj0t6c6GAD7evrIk8zbeUb6nK8dcUPAiAWM8uDX/1NmRTvLM9+1Vnn49hwKtEzw==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+          "url": "https://github.com/sponsors/ethers-io/"
         },
         {
           "type": "individual",
@@ -2534,37 +2767,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
+        "@adraffy/ens-normalize": "1.9.0",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "aes-js": "4.0.0-beta.3",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2988,6 +3205,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -3006,6 +3224,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -3065,7 +3284,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.4",
@@ -3470,7 +3690,8 @@
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3649,12 +3870,14 @@
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -4321,7 +4544,8 @@
     "node_modules/scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "7.3.8",
@@ -4928,11 +5152,11 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -5036,6 +5260,11 @@
     }
   },
   "dependencies": {
+    "@adraffy/ens-normalize": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
+      "integrity": "sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ=="
+    },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -5114,6 +5343,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
       "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -5130,6 +5360,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
       "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -5144,6 +5375,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
       "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -5156,6 +5388,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
       "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -5168,6 +5401,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
       "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0"
       }
@@ -5176,6 +5410,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
       "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/properties": "^5.7.0"
@@ -5185,6 +5420,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
       "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
@@ -5195,6 +5431,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
       "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.7.0"
       }
@@ -5203,6 +5440,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
       "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.7.0"
       }
@@ -5211,6 +5449,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
       "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+      "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/abstract-provider": "^5.7.0",
@@ -5233,12 +5472,53 @@
         "@ethersproject/web": "^5.7.0",
         "ethers": "^5.7.0",
         "scrypt-js": "3.0.1"
+      },
+      "dependencies": {
+        "ethers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+          "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "5.7.0",
+            "@ethersproject/abstract-provider": "5.7.0",
+            "@ethersproject/abstract-signer": "5.7.0",
+            "@ethersproject/address": "5.7.0",
+            "@ethersproject/base64": "5.7.0",
+            "@ethersproject/basex": "5.7.0",
+            "@ethersproject/bignumber": "5.7.0",
+            "@ethersproject/bytes": "5.7.0",
+            "@ethersproject/constants": "5.7.0",
+            "@ethersproject/contracts": "5.7.0",
+            "@ethersproject/hash": "5.7.0",
+            "@ethersproject/hdnode": "5.7.0",
+            "@ethersproject/json-wallets": "5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/logger": "5.7.0",
+            "@ethersproject/networks": "5.7.1",
+            "@ethersproject/pbkdf2": "5.7.0",
+            "@ethersproject/properties": "5.7.0",
+            "@ethersproject/providers": "5.7.2",
+            "@ethersproject/random": "5.7.0",
+            "@ethersproject/rlp": "5.7.0",
+            "@ethersproject/sha2": "5.7.0",
+            "@ethersproject/signing-key": "5.7.0",
+            "@ethersproject/solidity": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "@ethersproject/transactions": "5.7.0",
+            "@ethersproject/units": "5.7.0",
+            "@ethersproject/wallet": "5.7.0",
+            "@ethersproject/web": "5.7.1",
+            "@ethersproject/wordlists": "5.7.0"
+          }
+        }
       }
     },
     "@ethersproject/hash": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
       "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -5255,6 +5535,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
       "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/basex": "^5.7.0",
@@ -5274,6 +5555,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
       "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -5288,12 +5570,21 @@
         "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
+      },
+      "dependencies": {
+        "aes-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+          "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+          "dev": true
+        }
       }
     },
     "@ethersproject/keccak256": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
       "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "js-sha3": "0.8.0"
@@ -5302,12 +5593,14 @@
     "@ethersproject/logger": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
-      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+      "dev": true
     },
     "@ethersproject/networks": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
       "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.7.0"
       }
@@ -5316,6 +5609,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
       "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/sha2": "^5.7.0"
@@ -5325,6 +5619,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
       "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.7.0"
       }
@@ -5333,6 +5628,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
       "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -5354,12 +5650,22 @@
         "@ethersproject/web": "^5.7.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "dev": true,
+          "requires": {}
+        }
       }
     },
     "@ethersproject/random": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
       "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
@@ -5369,6 +5675,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
       "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
@@ -5378,6 +5685,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
       "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
@@ -5388,6 +5696,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
       "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
@@ -5401,6 +5710,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
       "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
+      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -5414,6 +5724,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
       "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/constants": "^5.7.0",
@@ -5424,6 +5735,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
       "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -5440,6 +5752,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
       "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
+      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/constants": "^5.7.0",
@@ -5450,6 +5763,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
       "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -5472,6 +5786,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
       "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+      "dev": true,
       "requires": {
         "@ethersproject/base64": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -5484,6 +5799,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
       "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/hash": "^5.7.0",
@@ -5543,6 +5859,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5598,6 +5924,46 @@
         "ethers": "^5.7.2",
         "shelljs": "^0.8.5",
         "yargs": "^17.5.1"
+      },
+      "dependencies": {
+        "ethers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+          "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "5.7.0",
+            "@ethersproject/abstract-provider": "5.7.0",
+            "@ethersproject/abstract-signer": "5.7.0",
+            "@ethersproject/address": "5.7.0",
+            "@ethersproject/base64": "5.7.0",
+            "@ethersproject/basex": "5.7.0",
+            "@ethersproject/bignumber": "5.7.0",
+            "@ethersproject/bytes": "5.7.0",
+            "@ethersproject/constants": "5.7.0",
+            "@ethersproject/contracts": "5.7.0",
+            "@ethersproject/hash": "5.7.0",
+            "@ethersproject/hdnode": "5.7.0",
+            "@ethersproject/json-wallets": "5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/logger": "5.7.0",
+            "@ethersproject/networks": "5.7.1",
+            "@ethersproject/pbkdf2": "5.7.0",
+            "@ethersproject/properties": "5.7.0",
+            "@ethersproject/providers": "5.7.2",
+            "@ethersproject/random": "5.7.0",
+            "@ethersproject/rlp": "5.7.0",
+            "@ethersproject/sha2": "5.7.0",
+            "@ethersproject/signing-key": "5.7.0",
+            "@ethersproject/solidity": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "@ethersproject/transactions": "5.7.0",
+            "@ethersproject/units": "5.7.0",
+            "@ethersproject/wallet": "5.7.0",
+            "@ethersproject/web": "5.7.1",
+            "@ethersproject/wordlists": "5.7.0"
+          }
+        }
       }
     },
     "@tableland/sdk": {
@@ -5616,6 +5982,44 @@
           "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.0.5.tgz",
           "integrity": "sha512-dotXZulYNKdxLNbGkenQGAjuQfuXFRcxUqtt8ffyoNG3n6llUVOnTVXWjcSL0B36kMSVul7XpfKSQkGOa13awg==",
           "dev": true
+        },
+        "ethers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+          "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "5.7.0",
+            "@ethersproject/abstract-provider": "5.7.0",
+            "@ethersproject/abstract-signer": "5.7.0",
+            "@ethersproject/address": "5.7.0",
+            "@ethersproject/base64": "5.7.0",
+            "@ethersproject/basex": "5.7.0",
+            "@ethersproject/bignumber": "5.7.0",
+            "@ethersproject/bytes": "5.7.0",
+            "@ethersproject/constants": "5.7.0",
+            "@ethersproject/contracts": "5.7.0",
+            "@ethersproject/hash": "5.7.0",
+            "@ethersproject/hdnode": "5.7.0",
+            "@ethersproject/json-wallets": "5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/logger": "5.7.0",
+            "@ethersproject/networks": "5.7.1",
+            "@ethersproject/pbkdf2": "5.7.0",
+            "@ethersproject/properties": "5.7.0",
+            "@ethersproject/providers": "5.7.2",
+            "@ethersproject/random": "5.7.0",
+            "@ethersproject/rlp": "5.7.0",
+            "@ethersproject/sha2": "5.7.0",
+            "@ethersproject/signing-key": "5.7.0",
+            "@ethersproject/solidity": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "@ethersproject/transactions": "5.7.0",
+            "@ethersproject/units": "5.7.0",
+            "@ethersproject/wallet": "5.7.0",
+            "@ethersproject/web": "5.7.1",
+            "@ethersproject/wordlists": "5.7.0"
+          }
         }
       }
     },
@@ -5858,9 +6262,9 @@
       "dev": true
     },
     "aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.3.tgz",
+      "integrity": "sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA=="
     },
     "ajv": {
       "version": "6.12.6",
@@ -5993,7 +6397,8 @@
     "bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -6004,7 +6409,8 @@
     "bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -6028,7 +6434,8 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -6281,6 +6688,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -6294,7 +6702,8 @@
         "bn.js": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
         }
       }
     },
@@ -6725,40 +7134,23 @@
       "dev": true
     },
     "ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.3.0.tgz",
+      "integrity": "sha512-CKFYvTne1YT4S1glTiu7TgGsj0t6c6GAD7evrIk8zbeUb6nK8dcUPAiAWM8uDX/1NmRTvLM9+1Vnn49hwKtEzw==",
       "requires": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
+        "@adraffy/ens-normalize": "1.9.0",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "aes-js": "4.0.0-beta.3",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
       }
     },
     "fast-deep-equal": {
@@ -7070,6 +7462,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -7085,6 +7478,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -7132,7 +7526,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "internal-slot": {
       "version": "1.0.4",
@@ -7404,7 +7799,8 @@
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -7540,12 +7936,14 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.1.2",
@@ -7994,7 +8392,8 @@
     "scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true
     },
     "semver": {
       "version": "7.3.8",
@@ -8446,9 +8845,9 @@
       "dev": true
     },
     "ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "requires": {}
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -109,6 +109,6 @@
   "dependencies": {
     "@tableland/evm": "^4.2.2",
     "@tableland/sqlparser": "^1.0.6-pre.5",
-    "ethers": "^5.7.2"
+    "ethers": "^6.3.0"
   }
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -27,10 +27,10 @@ export {
 } from "./config.js";
 export {
   type Signer,
-  type ExternalProvider,
+  type Eip1193Provider,
   getDefaultProvider,
-  type ContractTransaction,
-  type ContractReceipt,
+  type ContractTransactionResponse,
+  type ContractTransactionReceipt,
   type RegistryReceipt,
   type MultiEventTransactionReceipt,
   getSigner,

--- a/src/lowlevel.ts
+++ b/src/lowlevel.ts
@@ -1,6 +1,7 @@
 import {
   type Config,
   extractBaseUrl,
+  extractChainId,
   extractSigner,
   type Signal,
   type ReadConfig,
@@ -78,7 +79,7 @@ export async function exec(
   { type, sql, tables: [first] }: ExtractedStatement
 ): Promise<WaitableTransactionReceipt> {
   const signer = await extractSigner(config);
-  const chainId = await signer.getChainId();
+  const chainId = await extractChainId(config);
   const baseUrl = await extractBaseUrl(config, chainId);
   const _config = { baseUrl, signer };
   const _params = { chainId, first, statement: sql };

--- a/src/registry/controller.ts
+++ b/src/registry/controller.ts
@@ -1,5 +1,6 @@
+import { Typed } from "ethers";
 import { type SignerConfig } from "../helpers/config.js";
-import { type ContractTransaction } from "../helpers/ethers.js";
+import { type ContractTransactionResponse } from "../helpers/ethers.js";
 import { type TableIdentifier, getContractSetup } from "./contract.js";
 
 export interface SetParams {
@@ -16,26 +17,35 @@ export interface SetParams {
 export async function setController(
   { signer }: SignerConfig,
   params: SetParams
-): Promise<ContractTransaction> {
+): Promise<ContractTransactionResponse> {
   const { contract, overrides, tableId } = await getContractSetup(
     signer,
     params.tableName
   );
   const caller = await signer.getAddress();
   const controller = params.controller;
-  return await contract.setController(caller, tableId, controller, overrides);
+  return await contract.setController(
+    Typed.address(caller),
+    Typed.uint256(tableId),
+    Typed.address(controller),
+    overrides
+  );
 }
 
 export async function lockController(
   { signer }: SignerConfig,
   tableName: string | TableIdentifier
-): Promise<ContractTransaction> {
+): Promise<ContractTransactionResponse> {
   const { contract, overrides, tableId } = await getContractSetup(
     signer,
     tableName
   );
   const caller = await signer.getAddress();
-  return await contract.lockController(caller, tableId, overrides);
+  return await contract.lockController(
+    Typed.address(caller),
+    Typed.uint256(tableId),
+    overrides
+  );
 }
 
 export async function getController(
@@ -46,5 +56,5 @@ export async function getController(
     signer,
     tableName
   );
-  return await contract.getController(tableId, overrides);
+  return await contract.getController(Typed.uint256(tableId), overrides);
 }

--- a/src/registry/create.ts
+++ b/src/registry/create.ts
@@ -1,6 +1,7 @@
+import { Typed } from "ethers";
 import { normalize } from "../helpers/index.js";
 import { type SignerConfig } from "../helpers/config.js";
-import { type ContractTransaction } from "../helpers/ethers.js";
+import { type ContractTransactionResponse } from "../helpers/ethers.js";
 import { validateTableName } from "../helpers/parser.js";
 import { getContractAndOverrides } from "./contract.js";
 
@@ -84,14 +85,14 @@ export type CreateParams = CreateOneParams | CreateManyParams;
 export async function createTable(
   config: SignerConfig,
   params: CreateOneParams
-): Promise<ContractTransaction> {
+): Promise<ContractTransactionResponse> {
   return await _createOne(config, params);
 }
 
 export async function create(
   config: SignerConfig,
   params: CreateParams
-): Promise<ContractTransaction> {
+): Promise<ContractTransactionResponse> {
   if (isCreateOne(params)) {
     return await _createOne(config, params);
   }
@@ -101,27 +102,31 @@ export async function create(
 async function _createOne(
   { signer }: SignerConfig,
   { statement, chainId }: CreateOneParams
-): Promise<ContractTransaction> {
+): Promise<ContractTransactionResponse> {
   const owner = await signer.getAddress();
   const { contract, overrides } = await getContractAndOverrides(
     signer,
     chainId
   );
-  return await contract["create(address,string)"](owner, statement, overrides);
+  return await contract.create(
+    Typed.address(owner),
+    Typed.statement(statement),
+    overrides
+  );
 }
 
 async function _createMany(
   { signer }: SignerConfig,
   { statements, chainId }: CreateManyParams
-): Promise<ContractTransaction> {
+): Promise<ContractTransactionResponse> {
   const owner = await signer.getAddress();
   const { contract, overrides } = await getContractAndOverrides(
     signer,
     chainId
   );
-  return await contract["create(address,string[])"](
-    owner,
-    statements,
+  return await contract.create(
+    Typed.address(owner),
+    Typed.array(statements.map((stmt) => Typed.string(stmt))),
     overrides
   );
 }

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -1,7 +1,7 @@
 import {
   type SignerConfig,
   type Signer,
-  type ContractTransaction,
+  type ContractTransactionResponse,
 } from "../helpers/index.js";
 import { type TableIdentifier } from "./contract.js";
 import { listTables } from "./tables.js";
@@ -89,7 +89,9 @@ export class Registry {
    *
    * Requires the msg sender to be the owner, approved, or operator
    */
-  async safeTransferFrom(params: TransferParams): Promise<ContractTransaction> {
+  async safeTransferFrom(
+    params: TransferParams
+  ): Promise<ContractTransactionResponse> {
     return await safeTransferFrom(this.config, params);
   }
 
@@ -117,7 +119,7 @@ export class Registry {
    * - `tableId` must exist
    * - `tableId` controller must not be locked
    */
-  async setController(params: SetParams): Promise<ContractTransaction> {
+  async setController(params: SetParams): Promise<ContractTransactionResponse> {
     return await setController(this.config, params);
   }
 
@@ -138,7 +140,7 @@ export class Registry {
    */
   async lockController(
     table: string | TableIdentifier
-  ): Promise<ContractTransaction> {
+  ): Promise<ContractTransactionResponse> {
     return await lockController(this.config, table);
   }
 
@@ -161,14 +163,7 @@ export class Registry {
    *
    * - contract must be unpaused
    */
-  async create(params: CreateParams): Promise<ContractTransaction> {
-    return await create(this.config, params);
-  }
-
-  /**
-   * @custom:deprecated Use `create` instead.
-   */
-  async createTable(params: CreateOneParams): Promise<ContractTransaction> {
+  async create(params: CreateParams): Promise<ContractTransactionResponse> {
     return await create(this.config, params);
   }
 
@@ -187,15 +182,7 @@ export class Registry {
    * - `caller` must be authorized by the table controller
    * - `statement` must be less than 35000 bytes after normalizing
    */
-  async mutate(params: MutateParams): Promise<ContractTransaction> {
-    return await mutate(this.config, params);
-  }
-
-  /**
-   * Runs a set of SQL statements for `caller` using `runnables`.
-   * @custom:deprecated Using this with a single statement is deprecated. Use `mutate` instead.
-   */
-  async runSQL(params: MutateParams): Promise<ContractTransaction> {
+  async mutate(params: MutateParams): Promise<ContractTransactionResponse> {
     return await mutate(this.config, params);
   }
 }

--- a/src/registry/tables.ts
+++ b/src/registry/tables.ts
@@ -1,17 +1,26 @@
-import { type SignerConfig } from "../helpers/config.js";
+import { Typed } from "ethers";
+import {
+  type SignerConfig,
+  extractChainId,
+  extractSigner,
+} from "../helpers/config.js";
 import { type TableIdentifier, getContractAndOverrides } from "./contract.js";
 
 export async function listTables(
-  { signer }: SignerConfig,
+  config: SignerConfig,
   owner?: string
 ): Promise<TableIdentifier[]> {
+  const chainId = await extractChainId(config);
+  const signer = await extractSigner(config);
   const address = owner ?? (await signer.getAddress());
-  const chainId = await signer.getChainId();
-  signer._checkProvider();
+
   const { contract, overrides } = await getContractAndOverrides(
     signer,
     chainId
   );
-  const tokens = await contract.tokensOfOwner(address, overrides);
+  const tokens = await contract.tokensOfOwner(
+    Typed.address(address),
+    overrides
+  );
   return tokens.map((token) => ({ tableId: token.toString(), chainId }));
 }

--- a/src/registry/transfer.ts
+++ b/src/registry/transfer.ts
@@ -1,5 +1,6 @@
+import { Typed } from "ethers";
 import { type SignerConfig } from "../helpers/config.js";
-import { type ContractTransaction } from "../helpers/ethers.js";
+import { type ContractTransactionResponse } from "../helpers/ethers.js";
 import { type TableIdentifier, getContractSetup } from "./contract.js";
 
 export interface TransferParams {
@@ -16,16 +17,16 @@ export interface TransferParams {
 export async function safeTransferFrom(
   { signer }: SignerConfig,
   params: TransferParams
-): Promise<ContractTransaction> {
+): Promise<ContractTransactionResponse> {
   const { contract, overrides, tableId } = await getContractSetup(
     signer,
     params.tableName
   );
   const caller = await signer.getAddress();
-  return await contract["safeTransferFrom(address,address,uint256)"](
-    caller,
-    params.to,
-    tableId,
+  return await contract.safeTransferFrom(
+    Typed.address(caller),
+    Typed.address(params.to),
+    Typed.uint256(tableId),
     overrides
   );
 }

--- a/src/registry/utils.ts
+++ b/src/registry/utils.ts
@@ -12,7 +12,7 @@ import {
   extractChainId,
 } from "../helpers/config.js";
 import {
-  type ContractTransaction,
+  type ContractTransactionResponse,
   getContractReceipt,
 } from "../helpers/ethers.js";
 import { validateTables, type StatementType } from "../helpers/parser.js";
@@ -154,7 +154,7 @@ export async function extractReadonly(
 export async function wrapTransaction(
   conn: Config,
   prefix: string,
-  tx: ContractTransaction
+  tx: ContractTransactionResponse
 ): Promise<WaitableTransactionReceipt> {
   const _params = await getContractReceipt(tx);
   const chainId =
@@ -191,7 +191,7 @@ interface MultiEventTransaction {
 export async function wrapManyTransaction(
   conn: Config,
   statements: string[] | Runnable[],
-  tx: ContractTransaction
+  tx: ContractTransactionResponse
 ): Promise<WaitableTransactionReceipt & MultiEventTransaction> {
   const _params = await getContractReceipt(tx);
   const chainId =

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -81,6 +81,12 @@ export class Validator {
    * @description Returns information about a single table, including schema information
    */
   async getTableById(params: TableParams, opts: Signal = {}): Promise<Table> {
+    if (
+      typeof params.chainId !== "number" ||
+      typeof params.tableId !== "string"
+    ) {
+      throw new Error("cannot get table with invalid chain or table id");
+    }
     return await getTable(this.config, params);
   }
 

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -283,6 +283,36 @@ describe("validator", function () {
           return true;
         }
       );
+
+      await rejects(
+        // @ts-expect-error this is not the function signature
+        api.getTableById(31337, "1"),
+        (err: any) => {
+          strictEqual(
+            err.message,
+            "cannot get table with invalid chain or table id"
+          );
+          return true;
+        }
+      );
+
+      await rejects(
+        // params have wrong types
+        api.getTableById({
+          // @ts-expect-error we want to test that these params are being runtime type checked
+          chainId: "31337",
+          // @ts-expect-error must ensure that tableId is not a number because erc721 tokenId can be
+          // larger then JS max safe int, and string coercion will result in an incorrect value
+          tableId: 1,
+        }),
+        (err: any) => {
+          strictEqual(
+            err.message,
+            "cannot get table with invalid chain or table id"
+          );
+          return true;
+        }
+      );
     });
 
     test("when we call the tables api on a missing table", async function () {
@@ -456,7 +486,7 @@ describe("validator", function () {
   describe("rate limit", function () {
     test("when we make too many calls and get an exception", async function () {
       await rejects(
-        Promise.all(getRange(10).map(async () => await api.health())),
+        Promise.all(getRange(15).map(async () => await api.health())),
         (err: any) => {
           strictEqual(err.message, "Too Many Requests");
           return true;


### PR DESCRIPTION
fix tablelandnetwork/tableland-js#41 
This is blocked by changes needed in [evm-tableland](https://github.com/tablelandnetwork/evm-tableland/issues/337) which have to wait until Open Zeppelin supports ethers v6.