### PR TITLE
replace deprecated runSQL contract method

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -159,7 +159,7 @@ export class Registry {
    * - `msg.sender` must be `caller` or contract owner
    * - `tableId` must exist
    * - `caller` must be authorized by the table controller
-   * - `statement` must be less than or equal to 35000 bytes
+   * - `statement` must be less than or equal to 35000 bytes after normalizing
    */
   async runSQL(params: RunSQLParams): Promise<ContractTransaction> {
     return await runSQL(this.config, params);

--- a/src/registry/run.ts
+++ b/src/registry/run.ts
@@ -48,5 +48,5 @@ export async function runSQL(
     signer,
     chainId
   );
-  return await contract.runSQL(caller, tableId, statement, overrides);
+  return await contract.writeToTable(caller, tableId, statement, overrides);
 }


### PR DESCRIPTION
After the changes in https://github.com/tablelandnetwork/evm-tableland/pull/257 are deployed to all of our chains, and lands in local-tableland, this PR will be a patch update to replace the deprecated Registry Contract method use.