### PR TITLE
Ensure tableId is valid type at runtime

### DIFF
--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -81,6 +81,12 @@ export class Validator {
    * @description Returns information about a single table, including schema information
    */
   async getTableById(params: TableParams, opts: Signal = {}): Promise<Table> {
+    if (
+      typeof params.chainId !== "number" ||
+      typeof params.tableId !== "string"
+    ) {
+      throw new Error("cannot get table with invalid chain or table id");
+    }
     return await getTable(this.config, params);
   }
 

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -283,6 +283,36 @@ describe("validator", function () {
           return true;
         }
       );
+
+      await rejects(
+        // @ts-expect-error this is not the function signature
+        api.getTableById(31337, "1"),
+        (err: any) => {
+          strictEqual(
+            err.message,
+            "cannot get table with invalid chain or table id"
+          );
+          return true;
+        }
+      );
+
+      await rejects(
+        // params have wrong types
+        api.getTableById({
+          // @ts-expect-error we want to test that these params are being runtime type checked
+          chainId: "31337",
+          // @ts-expect-error must ensure that tableId is not a number because erc721 tokenId can be
+          // larger then JS max safe int, and string coercion will result in an incorrect value
+          tableId: 1,
+        }),
+        (err: any) => {
+          strictEqual(
+            err.message,
+            "cannot get table with invalid chain or table id"
+          );
+          return true;
+        }
+      );
     });
 
     test("when we call the tables api on a missing table", async function () {
@@ -456,7 +486,7 @@ describe("validator", function () {
   describe("rate limit", function () {
     test("when we make too many calls and get an exception", async function () {
       await rejects(
-        Promise.all(getRange(10).map(async () => await api.health())),
+        Promise.all(getRange(15).map(async () => await api.health())),
         (err: any) => {
           strictEqual(err.message, "Too Many Requests");
           return true;


### PR DESCRIPTION
## Overview
This makes the error message returned from an invalid call to `Validator.getTableById()` easier to understand.  

## Details
@dtbuchholz After looking into this I was reminded that the types are being generated from our API spec, so allowing tableId to be number or string or BigNumber was not a good solution.  Forcing the type to be string at runtime seems like the best path.
Interesting side note: in the process of setting this up I noticed that if you call
`validator.getTableById({chainId: 31337, tableId: 9007199254740993});`
the resulting http request is
`<api path>/tables/31337/9007199254740992`
Specifically anything bigger than Number.MAX_SAFE_INTEGER will potentially result in a request for the wrong  table.  Not a big deal because there are nowhere near that many tables.

fixes #470 
