### PR TITLE
Use new openapi spec with receipt table_ids field

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "coverage": "c8 --exclude src/validator/client/fetcher.ts --exclude test mocha --exit",
     "docs": "typedoc --entryPoints src/index.ts",
     "clean": "rm -rf dist coverage docs",
-    "build:api": "npx openapi-typescript https://raw.githubusercontent.com/tablelandnetwork/docs/45868461a4b268fe6a62913648971cce87d2ffbb/specs/validator/tableland-openapi-spec.yaml --output src/validator/client/validator.ts --immutable-types --path-params-as-types",
+    "build:api": "npx openapi-typescript https://raw.githubusercontent.com/tablelandnetwork/docs/main/specs/validator/tableland-openapi-spec.yaml --output src/validator/client/validator.ts --immutable-types --path-params-as-types",
     "build:esm": "npx tsc",
     "build:cjs": "npx tsc -p tsconfig.cjs.json",
     "build": "npm run build:api && npm run build:esm && npm run build:cjs && ./fixup"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "coverage": "c8 --exclude src/validator/client/fetcher.ts --exclude test mocha --exit",
     "docs": "typedoc --entryPoints src/index.ts",
     "clean": "rm -rf dist coverage docs",
-    "build:api": "npx openapi-typescript https://raw.githubusercontent.com/tablelandnetwork/docs/main/specs/validator/tableland-openapi-spec.yaml --output src/validator/client/validator.ts --immutable-types --path-params-as-types",
+    "build:api": "npx openapi-typescript https://raw.githubusercontent.com/tablelandnetwork/docs/45868461a4b268fe6a62913648971cce87d2ffbb/specs/validator/tableland-openapi-spec.yaml --output src/validator/client/validator.ts --immutable-types --path-params-as-types",
     "build:esm": "npx tsc",
     "build:cjs": "npx tsc -p tsconfig.cjs.json",
     "build": "npm run build:api && npm run build:esm && npm run build:cjs && ./fixup"

--- a/src/database.ts
+++ b/src/database.ts
@@ -95,12 +95,7 @@ export class Database<D = unknown> {
     opts: Signal = {}
     // reads returns an Array with legnth equal to the number of batched statements,
     // everything else a single result wrapped in an Array for backward compatability.
-    // TODO: In order to work around the Validator API not returning all of the tableIds
-    //       and continuing to work in a backward compatable way, it seems that we have to
-    //       make this type `any` :(
-    //       We should attempt to fix this when the Validator API update happens, or on the
-    //       next major version.
-  ): Promise<any> {
+  ): Promise<Array<Result<T>>> {
     try {
       const start = performance.now();
       // If the statement types are "create" and the statement contains more than one

--- a/src/validator/client/validator.ts
+++ b/src/validator/client/validator.ts
@@ -51,9 +51,9 @@ export interface components {
       readonly name?: string;
       /** @example https://testnets.tableland.network/api/v1/tables/healthbot_5_1 */
       readonly external_url?: string;
-      /** @example https://render.tableland.xyz/anim/?chain=1&id=1 */
+      /** @example https://tables.tableland.xyz/1/1.html */
       readonly animation_url?: string;
-      /** @example https://render.tableland.xyz/healthbot_5_1 */
+      /** @example https://tables.tableland.xyz/healthbot_5_1 */
       readonly image?: string;
       /**
        * @example {
@@ -73,8 +73,19 @@ export interface components {
       readonly schema?: components["schemas"]["Schema"];
     };
     readonly TransactionReceipt: {
-      /** @example 1 */
+      /**
+       * @deprecated 
+       * @description This field is deprecated 
+       * @example 1
+       */
       readonly table_id?: string;
+      /**
+       * @example [
+       *   "1",
+       *   "2"
+       * ]
+       */
+      readonly table_ids?: readonly (string)[];
       /** @example 0x02f319429b8a7be1cbb492f0bfbf740d2472232a2edadde7df7c16c0b61aa78b */
       readonly transaction_hash?: string;
       /**

--- a/src/validator/client/validator.ts
+++ b/src/validator/client/validator.ts
@@ -47,13 +47,13 @@ export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
     readonly Table: {
-      /** @example healthbot_5_1 */
+      /** @example healthbot_80001_1 */
       readonly name?: string;
-      /** @example https://testnets.tableland.network/api/v1/tables/healthbot_5_1 */
+      /** @example https://testnets.tableland.network/api/v1/tables/80001/1 */
       readonly external_url?: string;
-      /** @example https://tables.tableland.xyz/1/1.html */
+      /** @example https://tables.testnets.tableland.xyz/80001/1.html */
       readonly animation_url?: string;
-      /** @example https://tables.tableland.xyz/healthbot_5_1 */
+      /** @example https://tables.testnets.tableland.xyz/80001/1.svg */
       readonly image?: string;
       /**
        * @example {
@@ -68,7 +68,7 @@ export interface components {
           /** @description The trait type for marketplaces */
           readonly trait_type?: string;
           /** @description The value of the property */
-          readonly value?: string | number | number | boolean | Record<string, never>;
+          readonly value?: string | number | boolean | Record<string, never>;
         })[];
       readonly schema?: components["schemas"]["Schema"];
     };
@@ -190,7 +190,7 @@ export interface operations {
    */
   queryByStatement: {
     parameters: {
-      readonly query: {
+      query: {
         /**
          * @description The SQL read query statement 
          * @example select * from healthbot_80001_1
@@ -229,7 +229,7 @@ export interface operations {
    */
   receiptByTransactionHash: {
     parameters: {
-      readonly path: {
+      path: {
         /**
          * @description The parent chain to target 
          * @example 80001
@@ -263,7 +263,7 @@ export interface operations {
    */
   getTableById: {
     parameters: {
-      readonly path: {
+      path: {
         /**
          * @description The parent chain to target 
          * @example 80001

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -106,9 +106,10 @@ describe("database", function () {
       ]);
 
       const res = await batch.meta.txn?.wait();
+      const names = res?.names ?? [];
 
-      match(res.names[0], /^test_create_1_31337_\d+$/);
-      match(res.names[1], /^test_create_2_31337_\d+$/);
+      match(names[0], /^test_create_1_31337_\d+$/);
+      match(names[1], /^test_create_2_31337_\d+$/);
     });
 
     test("when batching mutations with a create throws an error", async function () {
@@ -169,9 +170,9 @@ describe("database", function () {
           `INSERT INTO ${tableName} (name, age) VALUES ('foo', 2);INSERT INTO ${tableName} (name, age) VALUES ('bar', 4);`
         ),
       ]);
-      const res = await batch1.meta.txn.wait();
+      const res = await batch1.meta.txn?.wait();
 
-      strictEqual(res.names.length, 1);
+      strictEqual(res?.names.length, 1);
     });
 
     test("when batching mutations with reads throws an error", async function () {
@@ -275,8 +276,8 @@ describe("database", function () {
       const [first, second] = batch.map((res: any) => res.results.length);
       assert(first >= 2 && second === first - 2);
       const { meta } = batch.pop() ?? {};
-      assert(meta.duration != null);
-      strictEqual(meta.txn, undefined);
+      assert(meta?.duration != null);
+      strictEqual(meta?.txn, undefined);
     });
 
     test("when using an abort controller to halt a batch of reads", async function () {
@@ -324,13 +325,13 @@ describe("database", function () {
         ]);
         // db has autoWait turned off
         const res = await batch.meta.txn?.wait();
+        const names = res?.names ?? [];
 
-        match(res.names[0], /^test_grant_1_31337_\d+$/);
-        match(res.names[1], /^test_grant_2_31337_\d+$/);
+        match(names[0], /^test_grant_1_31337_\d+$/);
+        match(names[1], /^test_grant_2_31337_\d+$/);
 
-        // TODO: batch return types aren't setup, so using `as` to keep linting happy
-        const tableName1 = res.names[0] as string;
-        const tableName2 = res.names[1] as string;
+        const tableName1 = names[0] ?? "";
+        const tableName2 = names[1] ?? "";
 
         const noPermission = db2.batch([
           db2.prepare(
@@ -366,7 +367,7 @@ describe("database", function () {
           ),
         ]);
 
-        const results = await db2.batch([
+        const results = await db2.batch<{ id: number; name: string }>([
           db2.prepare(`SELECT * FROM ${tableName1};`),
           db2.prepare(`SELECT * FROM ${tableName2};`),
         ]);
@@ -394,13 +395,13 @@ describe("database", function () {
         ]);
         // db has autoWait turned off
         const res = await batch.meta.txn?.wait();
+        const names = res?.names ?? [];
 
-        match(res.names[0], /^test_revoke_1_31337_\d+$/);
-        match(res.names[1], /^test_revoke_2_31337_\d+$/);
+        match(names[0], /^test_revoke_1_31337_\d+$/);
+        match(names[1], /^test_revoke_2_31337_\d+$/);
 
-        // TODO: batch return types aren't setup, so using `as` to keep linting happy
-        const tableName1 = res.names[0] as string;
-        const tableName2 = res.names[1] as string;
+        const tableName1 = names[0] ?? "";
+        const tableName2 = names[1] ?? "";
 
         // test after insert is granted
         const [batchGrant] = await db.batch([
@@ -419,7 +420,7 @@ describe("database", function () {
           ),
         ]);
 
-        const results = await db2.batch([
+        const results = await db2.batch<{ id: number; name: string }>([
           db2.prepare(`SELECT * FROM ${tableName1};`),
           db2.prepare(`SELECT * FROM ${tableName2};`),
         ]);


### PR DESCRIPTION
After the release of https://github.com/tablelandnetwork/docs/pull/11 and https://github.com/tablelandnetwork/go-tableland/pull/549 we can go back to using the Types that are generated from the spec.