### PR TITLE
Fix intermittent failing tests due to polling timeout

### DIFF
--- a/src/helpers/await.ts
+++ b/src/helpers/await.ts
@@ -24,20 +24,23 @@ export type AsyncFunction<T> = () => Awaitable<AsyncData<T>>;
 export function getAbortSignal(
   signal?: AbortSignal,
   maxTimeout: number = 60_000
-): AbortSignal {
+): {
+  signal: AbortSignal;
+  timeoutId: ReturnType<typeof setTimeout> | undefined;
+} {
   let abortSignal: AbortSignal;
+  let timeoutId;
   if (signal == null) {
     const controller = new AbortController();
     abortSignal = controller.signal;
-    console.log(`\n\nsetting maxTimeout: ${maxTimeout}\n\n`);
-    setTimeout(function () {
-      console.log(`\n\nAborting with maxTimeout: ${maxTimeout}\n\n`);
+    // return the timeoutId so the caller can cleanup
+    timeoutId = setTimeout(function () {
       controller.abort();
     }, maxTimeout);
   } else {
     abortSignal = signal;
   }
-  return abortSignal;
+  return { signal: abortSignal, timeoutId };
 }
 
 export async function getAsyncPoller<T = unknown>(
@@ -47,7 +50,7 @@ export async function getAsyncPoller<T = unknown>(
 ): Promise<T> {
   // in order to set a timeout other than 10 seconds you need to
   // create and pass in an abort signal with a different timeout
-  const abortSignal = getAbortSignal(signal, 10_000);
+  const { signal: abortSignal, timeoutId } = getAbortSignal(signal, 10_000);
   const checkCondition = (
     resolve: (value: T) => void,
     reject: (reason?: any) => void
@@ -55,9 +58,13 @@ export async function getAsyncPoller<T = unknown>(
     Promise.resolve(fn())
       .then((result: AsyncData<T>) => {
         if (result.done && result.data != null) {
+          // We don't want to call `AbortController.abort()` if the call succeeded
+          clearTimeout(timeoutId);
           return resolve(result.data);
         }
         if (abortSignal.aborted) {
+          // We don't want to call `AbortController.abort()` if the call is already aborted
+          clearTimeout(timeoutId);
           return reject(abortSignal.reason);
         } else {
           setTimeout(checkCondition, interval, resolve, reject);

--- a/src/helpers/await.ts
+++ b/src/helpers/await.ts
@@ -41,6 +41,8 @@ export async function getAsyncPoller<T = unknown>(
   interval: number = 1500,
   signal?: AbortSignal
 ): Promise<T> {
+  // in order to set a timeout other than 10 seconds you need to
+  // create and pass in an abort signal with a different timeout
   const abortSignal = getAbortSignal(signal, 10_000);
   const checkCondition = (
     resolve: (value: T) => void,

--- a/src/helpers/await.ts
+++ b/src/helpers/await.ts
@@ -29,7 +29,11 @@ export function getAbortSignal(
   if (signal == null) {
     const controller = new AbortController();
     abortSignal = controller.signal;
-    setTimeout(controller.abort.bind(controller), maxTimeout);
+    console.log(`\n\nsetting maxTimeout: ${maxTimeout}\n\n`);
+    setTimeout(function () {
+      console.log(`\n\nAborting with maxTimeout: ${maxTimeout}\n\n`);
+      controller.abort();
+    }, maxTimeout);
   } else {
     abortSignal = signal;
   }

--- a/test/await.test.ts
+++ b/test/await.test.ts
@@ -56,12 +56,12 @@ describe("await", function () {
   test("getAbortSignal returns a valid signal", async function () {
     const controller = new AbortController();
     const initial = controller.signal;
-    const signal = getAbortSignal(initial, 10);
+    const { signal } = getAbortSignal(initial, 10);
     strictEqual(signal.aborted, false);
     controller.abort();
     strictEqual(signal.aborted, true);
     strictEqual(initial.aborted, true);
-    const third = getAbortSignal(undefined, 10);
+    const { signal: third } = getAbortSignal(undefined, 10);
     strictEqual(third.aborted, false);
     await new Promise<void>(function (resolve) {
       third.addEventListener("abort", function abortListener() {

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -53,7 +53,7 @@ describe("database", function () {
     this.beforeAll(async function () {
       // need to increase the default timeout for the receipt polling
       // abort signal because github action runners are timing out
-      const signal = getAbortSignal(undefined, TEST_TIMEOUT_FACTOR * 60000);
+      const { signal } = getAbortSignal(undefined, TEST_TIMEOUT_FACTOR * 60000);
       const { results, error, meta } = await db
         .prepare(
           "CREATE TABLE test_batch (id integer, name text, age integer, primary key (id));"
@@ -465,7 +465,7 @@ describe("database", function () {
   describe(".exec()", function () {
     let tableName: string;
     this.beforeAll(async function () {
-      const signal = getAbortSignal(undefined, TEST_TIMEOUT_FACTOR * 30000);
+      const { signal } = getAbortSignal(undefined, TEST_TIMEOUT_FACTOR * 30000);
       const { results, error, meta } = await db
         .prepare(
           "CREATE TABLE test_exec (id integer, name text, age integer, primary key (id));"

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -51,10 +51,9 @@ describe("database", function () {
   describe(".batch()", function () {
     let tableName: string;
     this.beforeAll(async function () {
-      // TODO: it feels a little confusing to setup a create statement that has an extended
-      //    timeout and interval. Need to understand which part of this is a D1 data-source
-      //    compatability requirement, and what we can control.
-      const signal = getAbortSignal(undefined, TEST_TIMEOUT_FACTOR * 30000);
+      // need to increase the default timeout for the receipt polling
+      // abort signal because github action runners are timing out
+      const signal = getAbortSignal(undefined, TEST_TIMEOUT_FACTOR * 60000);
       const { results, error, meta } = await db
         .prepare(
           "CREATE TABLE test_batch (id integer, name text, age integer, primary key (id));"

--- a/test/lowlevel.test.ts
+++ b/test/lowlevel.test.ts
@@ -47,7 +47,7 @@ describe("lowlevel", function () {
           tables: ["test_exec"],
         }
       );
-      const signal = getAbortSignal(undefined, TEST_TIMEOUT_FACTOR * 30000);
+      const { signal } = getAbortSignal(undefined, TEST_TIMEOUT_FACTOR * 30000);
       await txn.wait({
         signal,
         interval: TEST_TIMEOUT_FACTOR * 1500,

--- a/test/lowlevel.test.ts
+++ b/test/lowlevel.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../src/lowlevel.js";
 import { extractReadonly } from "../src/registry/utils.js";
 import { getDelay } from "../src/helpers/utils.js";
+import { getAbortSignal } from "../src/helpers/await.js";
 import { TEST_TIMEOUT_FACTOR } from "./setup";
 
 // Just to test out these functions
@@ -46,6 +47,11 @@ describe("lowlevel", function () {
           tables: ["test_exec"],
         }
       );
+      const signal = getAbortSignal(undefined, TEST_TIMEOUT_FACTOR * 30000);
+      await txn.wait({
+        signal,
+        interval: TEST_TIMEOUT_FACTOR * 1500,
+      });
       strictEqual(txn.error, undefined);
       match(txn.name, /^test_exec_31337_\d+$/);
       const { name } = await txn.wait();

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -12,7 +12,7 @@ const getTimeoutFactor = function (): number {
 export const TEST_TIMEOUT_FACTOR = getTimeoutFactor();
 
 const lt = new LocalTableland({
-  silent: true,
+  silent: false,
 });
 
 before(async function () {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -12,7 +12,7 @@ const getTimeoutFactor = function (): number {
 export const TEST_TIMEOUT_FACTOR = getTimeoutFactor();
 
 const lt = new LocalTableland({
-  silent: false,
+  silent: true,
 });
 
 before(async function () {


### PR DESCRIPTION
## Overview
When tests are run via github actions, the tests are failing occasionally with an error saying "the operation was aborted".  Because reproducing this failure is difficult I can't be sure if these changes really fix the problem, but it seems related to our timeout abort controller. 

## Details
In searching for the cause of the test failures I discovered 2 potential problems.  
1. using a non-default polling interval is not possible.  The default is set to 1.5 seconds, which might be too fast for some networks. This is probably not the root cause of the failing tests, but it seems good to be able to reduce the polling interval if needed.
2. The `setTimeout` that is used to enforce the maximum amount of time that should be waited, while polling, is not ever being cleared.  This means that even if the request for a transaction receipt succeeds right away, we are still eventually calling `AbortController.abort()`.  This seems potentially related to the failing tests, but again, I can't say for sure since they only happen in the github actions workflow.
