### PR TITLE
fix: add missing `TableEventBus` export

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -44,3 +44,4 @@ export {
   type NormalizedStatement,
   type StatementType,
 } from "./parser.js";
+export { TableEventBus } from "./subscribe.js";


### PR DESCRIPTION
## Summary

The `helpers` module does not export the `TableEventBus`, so it is not possible to use the subscriptions feature.

## Details

Added the exported subscription class in `src/helpers/index.ts` with the line `export { TableEventBus } from "./subscribe.js";`. Without this, you'll receive an error like:

```
import { TableEventBus } from "@tableland/sdk/helpers";
         ^^^^^^^^^^^^^
SyntaxError: The requested module '@tableland/sdk/helpers' does not provide an export named 'TableEventBus'
```

## How it was tested

Tested locally with `npm link` using a separate project after building `js-tableland` locally with these changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
